### PR TITLE
docs: Stage 4.2 - Speed Insights & Web Analytics guides

### DIFF
--- a/docs/00-portfolio/features/performance-optimization.md
+++ b/docs/00-portfolio/features/performance-optimization.md
@@ -5,12 +5,14 @@ sidebar_position: 1
 tags: [features, brief, performance, caching, bundle, speed-insights, analytics]
 ---
 
-## Summary 
+## Summary
+
 **What was built:** A systematic approach to making the Portfolio App fast and keeping it fast over time.
 
 **Why it matters:** Enterprise reviewers expect production systems to be deliberately fast—not by accident, but by design with measurable proof. Stage 4.2 demonstrates that maturity.
 
 ## The Four Core Features
+
 ### 1. Pre-Rendering Pages (Static Generation + ISR)
 
 **What it does:** We build all project pages once at deploy time, rather than computing them fresh for each visitor
@@ -47,11 +49,13 @@ How it proves enterprise thinking: Shows deliberate optimization, not reactive f
 ## Monitoring & Documentation
 
 ### Performance Baseline:
+
 Documented target speeds (build time, bundle size, page load time)
 
 **Why:** Proves we measure and track; not guessing
 
 ### Vercel Speed Insights ([docs](https://vercel.com/docs/speed-insights)):
+
 Real-world Core Web Vitals data from actual visitor browsers (LCP, INP, CLS, FCP)
 
 **Why:** Proves it actually feels fast to real people, not just in theory
@@ -59,6 +63,7 @@ Real-world Core Web Vitals data from actual visitor browsers (LCP, INP, CLS, FCP
 **Packages:** `@vercel/speed-insights` with `<SpeedInsights />` component
 
 ### Vercel Web Analytics ([docs](https://vercel.com/docs/analytics)):
+
 Traffic analytics: page views, routes, referrers, devices, countries
 
 **Why:** Understand visitor behavior and traffic patterns
@@ -66,6 +71,7 @@ Traffic analytics: page views, routes, referrers, devices, countries
 **Packages:** `@vercel/analytics` with `<Analytics />` component
 
 ### Operational Runbook & Guide:
+
 Step-by-step procedures for analyzing and fixing performance issues
 
 **Why:** Demonstrates operational maturity; not "we ship it and hope"

--- a/docs/50-operations/runbooks/rbk-portfolio-performance-optimization.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-performance-optimization.md
@@ -2,7 +2,8 @@
 title: 'Runbook: Portfolio Performance Optimization & Monitoring'
 description: 'Procedures for verifying performance baselines, bundle size regressions, and Vercel Speed Insights (Core Web Vitals) for the Portfolio App.'
 sidebar_position: 9
-tags: [runbook, performance, optimization, monitoring, stage-4-2, speed-insights]
+tags:
+  [runbook, performance, optimization, monitoring, stage-4-2, speed-insights]
 ---
 
 ## Purpose
@@ -92,6 +93,7 @@ Operational steps to confirm performance baselines, detect regressions (bundle s
 #### Core Web Vitals Breakdown
 
 **Largest Contentful Paint (LCP)** - Loading Performance
+
 - **What it measures:** Time until largest content element appears (hero image, main heading, etc.)
 - **Target:** < 2.5 seconds
 - **Good:** 0-2500ms (green) | **Needs Improvement:** 2500-4000ms (orange) | **Poor:** > 4000ms (red)
@@ -99,6 +101,7 @@ Operational steps to confirm performance baselines, detect regressions (bundle s
 - **Dashboard view:** Click "LCP" in left panel → see breakdown by route/path/selector
 
 **Interaction to Next Paint (INP)** - Responsiveness (Primary Metric)
+
 - **What it measures:** Time from user interaction (click, tap, keypress) to browser rendering response
 - **Target:** < 200 milliseconds
 - **Good:** 0-200ms (green) | **Needs Improvement:** 200-500ms (orange) | **Poor:** > 500ms (red)
@@ -107,6 +110,7 @@ Operational steps to confirm performance baselines, detect regressions (bundle s
 - **Note:** INP replaced FID as the primary responsiveness metric (Lighthouse 10+)
 
 **Cumulative Layout Shift (CLS)** - Visual Stability
+
 - **What it measures:** How much page content shifts unexpectedly during load
 - **Target:** < 0.1
 - **Good:** 0-0.1 (green) | **Needs Improvement:** 0.1-0.25 (orange) | **Poor:** > 0.25 (red)
@@ -114,24 +118,28 @@ Operational steps to confirm performance baselines, detect regressions (bundle s
 - **Dashboard view:** Click "CLS" → see which elements cause layout shifts
 
 **First Contentful Paint (FCP)** - Initial Rendering
+
 - **What it measures:** Time until first text, image, or canvas element appears
 - **Target:** < 1.8 seconds
 - **Good:** 0-1800ms (green) | **Needs Improvement:** 1800-3000ms (orange) | **Poor:** > 3000ms (red)
 - **Dashboard view:** Click "FCP" → breakdown by route
 
 **First Input Delay (FID)** - Legacy Responsiveness (Deprecated)
+
 - **What it measures:** Time from first user interaction to browser response
 - **Target:** < 100 milliseconds
 - **Note:** Being replaced by INP; still tracked for historical comparison
 - **Status:** Use INP for modern analysis; FID for legacy baseline comparison
 
 **Other Metrics:**
+
 - **Total Blocking Time (TBT):** < 800ms - time main thread is blocked (Virtual Experience Score)
 - **Time to First Byte (TTFB):** < 800ms - server response time
 
 #### Analyzing Performance by Dimension
 
 **By Route/Path** (Most useful for identifying problem pages)
+
 1. Click any metric (e.g., LCP) in left panel
 2. Switch between **Route** (framework routes) vs **Path** (actual URLs) tabs
 3. Sort by:
@@ -141,12 +149,14 @@ Operational steps to confirm performance baselines, detect regressions (bundle s
 5. **Action:** Focus optimization on routes with orange/red scores AND high traffic
 
 **By HTML Selector** (Available for LCP, INP, CLS, FID)
+
 1. Click **Selectors** tab
 2. See specific HTML elements causing issues
 3. Example: `img.hero-image` causing slow LCP
 4. **Action:** Optimize identified elements (lazy load, compress, defer)
 
 **By Country** (Geographic Performance)
+
 1. Scroll to **Countries** section
 2. Map shows color-coded performance per region
 3. Click country for detailed breakdown
@@ -165,6 +175,7 @@ Operational steps to confirm performance baselines, detect regressions (bundle s
 #### Data Point Collection
 
 Speed Insights collects up to **6 data points per visit**:
+
 - **On page load:** TTFB, FCP
 - **On interaction:** FID, LCP
 - **On leave:** INP, CLS, LCP (if not already sent)
@@ -201,6 +212,7 @@ Speed Insights collects up to **6 data points per visit**:
 #### Purpose & Scope
 
 **Web Analytics tracks traffic & user behavior**, NOT performance metrics.
+
 - Page views, unique visitors, routes accessed
 - Referrer sources (where visitors came from)
 - Geographic distribution, devices, browsers, OS
@@ -211,16 +223,19 @@ Speed Insights collects up to **6 data points per visit**:
 #### Overview Metrics
 
 **Top of Dashboard:**
+
 1. **Visitors** - Unique visitors in selected timeframe
 2. **Page Views** - Total pages viewed
 3. **Average Visit Duration** - How long users stay on site
 4. **Bounce Rate** - % who leave after viewing one page
 
 **Time Selector** (top-right):
+
 - Predefined: Last 24h, 7d, 30d, 90d
 - Custom: Click calendar icon for specific date range
 
 **Environment Selector** (top-right):
+
 - **Production** (default) - Main site traffic
 - **Preview** - Preview deployment traffic (usually low/zero for public sites)
 - **All Environments** - Combined
@@ -228,25 +243,30 @@ Speed Insights collects up to **6 data points per visit**:
 #### Analyzing Traffic by Dimension
 
 **Pages Panel**
+
 - Lists all page URLs visited (without query params)
 - Shows views, unique visitors per page
 - **Action:** Identify most popular pages (focus optimization there)
 
 **Routes Panel**
+
 - Shows framework-defined routes (e.g., `/projects/[slug]`)
 - Useful for understanding route popularity
 - **Action:** If certain routes dominate traffic, ensure they're well-optimized
 
 **Referrers Panel**
+
 - Shows where visitors came from (external links, search engines, social media)
 - **Direct** = typed URL or bookmark
 - **Action:** Understand traffic sources; optimize for primary referrers
 
 **Countries Panel**
+
 - Geographic distribution of visitors
 - **Action:** If concentrated in specific regions, consider geo-targeted optimization
 
 **Browsers / Devices / Operating System Panels**
+
 - Browser usage (Chrome, Safari, Firefox, etc.)
 - Device types (Desktop, Mobile, Tablet)
 - OS distribution (Windows, macOS, iOS, Android)
@@ -255,6 +275,7 @@ Speed Insights collects up to **6 data points per visit**:
 #### Filtering Data
 
 Click filter icon on any panel to:
+
 - Include/exclude specific values
 - Combine filters across dimensions
 - **Example:** "Show mobile visitors from US who accessed /projects route"
@@ -269,6 +290,7 @@ Click filter icon on any panel to:
 #### Verifying Analytics Collection
 
 **Check Network Tab:**
+
 1. Open browser DevTools → Network tab
 2. Visit any page on deployed site
 3. Look for Fetch/XHR request to `/_vercel/insights/view`
@@ -277,36 +299,41 @@ Click filter icon on any panel to:
 #### Common Insights
 
 **High bounce rate on specific page:**
+
 - Content may not match user expectations (from referrer)
 - Slow load time (cross-reference with Speed Insights)
 - Broken navigation or unclear CTA
 
 **Low average visit duration:**
+
 - Content not engaging
 - Navigation issues
 - Mobile experience poor (check Devices panel)
 
 **Geographic concentration:**
+
 - If traffic heavily US-centric, consider if targeting is correct
 - If global, ensure CDN delivers well worldwide (check Speed Insights by country)
 
 **Unexpected referrers:**
+
 - May indicate backlinks or mentions
 - Verify referrers are legitimate (not spam/bot traffic)
 
 #### Comparison: Speed Insights vs Web Analytics
 
-| Aspect | Speed Insights | Web Analytics |
-|--------|----------------|---------------|
-| **Purpose** | Performance metrics | Traffic behavior |
-| **Key Metrics** | LCP, INP, CLS, FCP | Page views, visitors, referrers |
-| **Dashboard Tab** | `/speed-insights` | `/analytics` |
-| **Package** | `@vercel/speed-insights` | `@vercel/analytics` |
-| **Component** | `<SpeedInsights />` | `<Analytics />` |
-| **Script Path** | `/_vercel/speed-insights/script.js` | `/_vercel/insights/view` |
-| **Use When** | Diagnosing slow pages, optimizing load times | Understanding user behavior, traffic sources |
+| Aspect            | Speed Insights                               | Web Analytics                                |
+| ----------------- | -------------------------------------------- | -------------------------------------------- |
+| **Purpose**       | Performance metrics                          | Traffic behavior                             |
+| **Key Metrics**   | LCP, INP, CLS, FCP                           | Page views, visitors, referrers              |
+| **Dashboard Tab** | `/speed-insights`                            | `/analytics`                                 |
+| **Package**       | `@vercel/speed-insights`                     | `@vercel/analytics`                          |
+| **Component**     | `<SpeedInsights />`                          | `<Analytics />`                              |
+| **Script Path**   | `/_vercel/speed-insights/script.js`          | `/_vercel/insights/view`                     |
+| **Use When**      | Diagnosing slow pages, optimizing load times | Understanding user behavior, traffic sources |
 
 **Workflow Integration:**
+
 1. Use **Web Analytics** to identify high-traffic pages/routes
 2. Use **Speed Insights** to ensure those pages perform well
 3. Cross-reference: if high-traffic page has poor performance score, prioritize optimization

--- a/docs/70-reference/performance-optimization-guide.md
+++ b/docs/70-reference/performance-optimization-guide.md
@@ -2,7 +2,16 @@
 title: 'Performance Optimization Guide (Portfolio App)'
 description: 'Concise reference for bundle analysis, caching, and Vercel Speed Insights (Core Web Vitals) for the Portfolio App.'
 sidebar_position: 9
-tags: [reference, performance, caching, bundle, speed-insights, analytics, stage-4-2]
+tags:
+  [
+    reference,
+    performance,
+    caching,
+    bundle,
+    speed-insights,
+    analytics,
+    stage-4-2,
+  ]
 ---
 
 ## Purpose
@@ -69,27 +78,32 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
 ## Quick Decision Tree
 
 **"My app feels slow"**
+
 1. Check Speed Insights → Real Experience Score
 2. If RES < 90 (orange/red): Click worst metric → identify problem routes/selectors
 3. Optimize identified pages/elements
 4. Redeploy → verify RES improves
 
 **"Which pages should I optimize first?"**
+
 1. Open Web Analytics → note top 3 pages by traffic
 2. Open Speed Insights → check scores for those routes
 3. Prioritize: High traffic + Low score = urgent optimization target
 
 **"Did my recent deploy make things worse?"**
+
 1. Speed Insights → check RES time graph for sudden drops
 2. Compare Production vs Preview environments
 3. If Preview worse than Production: investigate before promoting
 
 **"Where are users coming from?"**
+
 1. Web Analytics → Referrers panel
 2. Cross-check with Countries panel for geographic distribution
 3. Action: Optimize for primary referrer sources (e.g., if LinkedIn dominates, ensure mobile experience excellent)
 
 **"Is a specific page broken?"**
+
 1. Web Analytics → Pages panel → find the page
 2. Check if views dropped suddenly (possible error or navigation break)
 3. Cross-check Speed Insights → that route → look for red metrics
@@ -103,12 +117,10 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
    - Verify RES ≥ 90 (green) for Production environment
    - Review 30-day trend: any drops?
    - Check all Core Web Vitals: any orange/red zones?
-   
 2. **If issues found:**
    - Click worst metric → sort routes by score
    - Export top 10 problem routes (three-dot menu → export)
    - For each route: check Selectors tab for specific elements causing issues
-   
 3. **Geographic check:**
    - Scroll to Countries map
    - Click any orange/red countries → see their metrics
@@ -146,17 +158,14 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
    - Find route `/projects/[slug]` → note score
    - Switch to **Selectors** tab → identify slow elements (likely images)
    - Check **Devices** breakdown: Mobile vs Desktop scores differ?
-   
 2. **Web Analytics:**
    - Devices panel → what % of traffic is mobile?
    - If mobile-dominant: mobile optimization is critical
-   
 3. **Local testing:**
    - Chrome DevTools → throttle to "Slow 4G"
    - Visit the project page
    - Network tab → find large assets
    - Performance tab → see what blocks rendering
-   
 4. **Fix:**
    - Optimize images (compress, lazy load, responsive sizes)
    - Redeploy to Preview
@@ -169,11 +178,9 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
    - Pages panel → sort by views (descending)
    - Note top 5 pages
    - Routes panel → see which route patterns dominate
-   
 2. **Insight:**
    - If `/projects/portfolio-app` gets 60% of traffic: ensure it's your best showcase
    - If `/cv` gets minimal traffic but you want it prominent: consider navigation changes
-   
 3. **Cross-reference Speed Insights:**
    - For top-traffic pages: verify green scores
    - Low-traffic pages with red scores: lower priority (but still address eventually)
@@ -192,8 +199,6 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
    - Speed Insights → LCP → find route
    - New score (e.g., 1.8s, green) → improvement confirmed!
    - Check time graph: see the drop at deployment timestamp
-   
 4. **Document win:**
    - "Optimized images reduced LCP from 3.2s → 1.8s (44% improvement)"
    - Use in portfolio narrative as evidence of performance work
-


### PR DESCRIPTION
# Summary

## What changed
- Added detailed Speed Insights dashboard guide (RES interpretation, percentiles, route/selector/country breakdowns) to runbook
- Added Web Analytics dashboard guide with comparison vs Speed Insights and troubleshooting
- Expanded reference guide with decision tree and workflows; aligned metrics (INP primary, FID legacy) and links to Vercel docs

## Why
- Align Stage 4.2 documentation with Vercel product split (Speed Insights vs Web Analytics)
- Provide operational workflows so reviewers can read and act on dashboard data confidently

## Scope
- [x] Docs content update
- [ ] New section/folder (_category_ + index hub)
- [ ] Templates / style guide
- [ ] CI/CD / workflows
- [ ] Security / threat model / SDLC controls
- [x] Operations / runbooks / IR / DR

## Evidence
- [ ] `ci / quality` passed (lint, typecheck, format)
- [ ] `ci / build` passed (Docusaurus build + broken links check)
- [ ] `codeql` checks passed
- [ ] Includes closing keyword for linked issue (e.g., Closes #123)
- Links / screenshots / notes: Not run (docs-only changes); CI will run on PR.

## Nav / Structure
- [ ] New/updated folders include `_category_.json` or `_category_.yml`
- [ ] New section has an index hub (generated-index or curated index doc)
- [x] Sidebars/autogenerated navigation renders correctly (no new sections added)

## Security
- [x] No secrets added (confirmed)
- [ ] If security-relevant: threat model / controls updated or issue created
  - Link to update/issue:

## Quality checklist
- [x] Front matter included (title, description, tags; sidebar fields if needed)
- [x] Uses standard page structure (Purpose / Scope / Procedure / Validation / Troubleshooting / Refs)
- [x] Commands are copy/paste safe and specify shell where provided
- [x] Any destructive steps include rollback guidance (runbook already includes recovery/rollback)

## Notes for reviewers (optional)
- Companion app PR: https://github.com/bryce-seefieldt/portfolio-app/pull/50
