### PR TITLE
ci(security): pin pnpm action to immutable v5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: '10.0.0'
 
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: '10.0.0'
 


### PR DESCRIPTION

# Summary

## What changed

This pull request updates the GitHub Actions workflow to use a specific commit hash for the `pnpm/action-setup` action instead of referencing it by version tag. This change helps ensure consistency and security in the CI pipeline.

Workflow dependency pinning:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R25): Updated the `pnpm/action-setup` action to use a specific commit hash (`fc06bc1257f339d1d5d8b3a19a8cae5388b55320`) in two places, instead of the general `v5` tag. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R25) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R74)