### PR TITLE
docs: close loop on pnpm/action-setup v6 exception tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,7 @@ updates:
     # 1) v6 update PR passes ci/quality, ci/build, and ci/policy-consistency
     # 2) no lockfile parser regression is observed in follow-up validation
     # 3) re-evaluate on or before 2026-06-01
+    # Tracking issue: #103
     ignore:
       - dependency-name: 'pnpm/action-setup'
 

--- a/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md
@@ -45,6 +45,7 @@ Use this section when a dependency-automation update repeatedly fails CI for env
 - Owner: Maintainer on-call
 - Opened: 2026-05-01
 - Review/expiry date: 2026-06-01
+- Tracking issue: [#103](https://github.com/bryce-seefieldt/portfolio-docs/issues/103)
 
 ### Why this exception exists
 
@@ -65,7 +66,7 @@ Use this section when a dependency-automation update repeatedly fails CI for env
 
 ### Required tracking actions
 
-1. Open a tracking issue labeled `dependencies` and `ci`.
+1. Open a tracking issue labeled `documentation` and `enhancement`.
 2. Link failing run evidence and this runbook section.
 3. Schedule a calendar reminder for the expiry date.
 4. Remove the Dependabot ignore immediately after successful revalidation.


### PR DESCRIPTION
## Summary
This PR closes the operational follow-up loop for the temporary pnpm/action-setup v6 exception.

## Changes
- Added tracking issue reference to .github/dependabot.yml (#103)
- Added tracking issue link to CI triage runbook
- Aligned runbook label guidance to labels that exist in this repository

## Context
- Tracking issue: #103
- Temporary exception review date: 2026-06-01

## Validation
- pnpm prettier --check .github/dependabot.yml docs/50-operations/runbooks/rbk-portfolio-ci-triage.md