### PR TITLE
docs(testing): align deterministic E2E vs external link monitor guidance

### DIFF
--- a/docs/00-portfolio/features/01-core-pages-reviewer-journey/cv-page.md
+++ b/docs/00-portfolio/features/01-core-pages-reviewer-journey/cv-page.md
@@ -46,8 +46,8 @@ tags: [portfolio, features, core-pages, cv]
 #### Manual
 
 - Steps: Open `/cv`, scan timeline entries, click at least two proof links.
-- What to look for: Evidence links resolve correctly and match the described capability.
-- Artifacts or reports to inspect: Optional E2E route coverage in CI.
+- What to look for: Evidence links point to expected destinations and match the described capability.
+- Artifacts or reports to inspect: Optional E2E route coverage in CI; optional external-link monitor results for live reachability.
 
 #### Tests
 
@@ -98,7 +98,7 @@ tags: [portfolio, features, core-pages, cv]
 ## Validation / Expected outcomes
 
 - CV timeline renders without missing sections.
-- Evidence links are functional and relevant to each capability.
+- Evidence links are relevant to each capability and route to the intended destinations.
 
 ## Failure modes / Troubleshooting
 

--- a/docs/00-portfolio/features/02-evidence-first-content-model/evidence-linking.md
+++ b/docs/00-portfolio/features/02-evidence-first-content-model/evidence-linking.md
@@ -8,7 +8,7 @@ tags: [portfolio, features, evidence, links]
 ## Purpose
 
 - Feature name: Evidence link construction
-- Why this feature exists: Ensure evidence links resolve correctly across preview, staging, and production environments.
+- Why this feature exists: Ensure evidence links are constructed consistently across preview, staging, and production environments.
 
 ## Scope
 
@@ -46,8 +46,8 @@ tags: [portfolio, features, evidence, links]
 #### Manual
 
 - Steps: Open a project page and click dossier and ADR links.
-- What to look for: Links resolve to the expected docs base URL across environments.
-- Artifacts or reports to inspect: Environment variable values and E2E evidence link checks.
+- What to look for: Links point to the expected docs base URL across environments.
+- Artifacts or reports to inspect: Environment variable values, E2E evidence-link DOM assertions, and optional external-link monitor runs for live reachability.
 
 #### Tests
 
@@ -97,7 +97,7 @@ tags: [portfolio, features, evidence, links]
 
 ## Validation / Expected outcomes
 
-- Evidence links resolve correctly in preview, staging, and production.
+- Evidence links are built with the correct base URL and expected paths in preview, staging, and production.
 - Docs base URL changes do not require code changes.
 
 ## Failure modes / Troubleshooting

--- a/docs/10-architecture/adr/adr-0012-cross-repo-documentation-linking.md
+++ b/docs/10-architecture/adr/adr-0012-cross-repo-documentation-linking.md
@@ -268,7 +268,7 @@ export function githubUrl(path: string): string {
 ### Phase 3: Unit & E2E Tests (Stage 3.3)
 
 - `src/lib/__tests__/config.test.ts`: 18 tests verifying `docsUrl()`, `githubUrl()` behavior with env vars set/unset
-- `e2e/evidence-links.spec.ts`: 12 Playwright tests verifying evidence links resolve correctly
+- `e2e/evidence-links.spec.ts`: 12 Playwright tests verifying evidence link rendering and href assertions
 - CI workflow exports required variables for tests to pass
 
 ---
@@ -307,7 +307,7 @@ describe('docsUrl', () => {
 ### E2E Tests
 
 ```typescript
-test('evidence links resolve correctly', async ({ page }) => {
+test('evidence links render with expected href values', async ({ page }) => {
   await page.goto('/projects/portfolio-app');
   const docsLink = page.locator('a[href*="/docs/"]');
   await expect(docsLink).toHaveAttribute(
@@ -327,7 +327,7 @@ This decision is considered successful if:
 - ✅ Links work in CI with environment variables set
 - ✅ Links work in production with production domains
 - ✅ Unit tests verify helper functions return correct URLs
-- ✅ E2E tests verify evidence links resolve
+- ✅ E2E tests verify evidence links render with expected href values
 - ✅ Cloning the repo and updating `.env` makes all links portable
 - ✅ Adding new cross-repo links follows same pattern
 - ✅ No hardcoded domains in application code

--- a/docs/30-devops-platform/ci-cd-pipeline-overview.md
+++ b/docs/30-devops-platform/ci-cd-pipeline-overview.md
@@ -15,6 +15,8 @@ Document the CI/CD pipeline architecture, job dependencies, test integration, an
 - Job sequence and dependencies
 - Quality gates (lint, format, typecheck, tests)
 - Test job integration (unit + E2E)
+- Link-validation integration (registry validation + full Playwright E2E suite)
+- External evidence-link monitoring (scheduled/manual, non-blocking)
 - Coverage reporting and artifacts
 - Build promotion and deployment
 
@@ -37,18 +39,24 @@ The Portfolio App CI/CD pipeline enforces quality gates via GitHub Actions befor
 ```mermaid
 graph TB
    Quality["Quality Job<br/>├─ Lint ESLint<br/>├─ Format check Prettier<br/>├─ Typecheck TypeScript<br/>├─ Dependency audit<br/>└─ Auto-format Dependabot PRs"]
-    Secrets["Secrets-Scan Job<br/>├─ TruffleHog scanning<br/>└─ Verified secrets only"]
+   Secrets["Secrets-Scan Job (PR only)<br/>├─ TruffleHog scanning<br/>└─ Verified secrets only"]
     Test["Test Job<br/>├─ Unit tests pnpm test:unit<br/>├─ E2E tests Playwright<br/>└─ Coverage reports artifacts"]
+   LinkValidation["Link-Validation Job<br/>├─ Registry validation<br/>└─ Full Playwright E2E via links:check"]
     Build["Build Job<br/>├─ pnpm build<br/>└─ Vercel deployment"]
+   ExternalMonitor["External Link Monitor<br/>├─ links:check:external<br/>└─ Scheduled/manual non-blocking"]
 
-    Quality --> Secrets
-    Secrets --> Test
-    Test --> Build
+   Quality --> Test
+   Quality --> LinkValidation
+   Test --> Build
+   LinkValidation --> Build
+   Secrets -.-> Build
 
     style Quality fill:#339af0,stroke:#1971c2,stroke-width:2px,color:#fff
     style Secrets fill:#339af0,stroke:#1971c2,stroke-width:2px,color:#fff
     style Test fill:#339af0,stroke:#1971c2,stroke-width:2px,color:#fff
+   style LinkValidation fill:#339af0,stroke:#1971c2,stroke-width:2px,color:#fff
     style Build fill:#339af0,stroke:#1971c2,stroke-width:2px,color:#fff
+   style ExternalMonitor fill:#ffd43b,stroke:#fab005,stroke-width:2px,color:#000
 ```
 
 ### Job Execution Details
@@ -74,7 +82,7 @@ graph TB
 2. **Setup pnpm**
 
    ```yaml
-   uses: pnpm/action-setup@v4
+   uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
    with:
      version: '10.0.0'
    ```
@@ -191,9 +199,8 @@ trufflesecurity/trufflehog@main \
    pnpm test:unit
    ```
 
-   - Vitest with coverage reporting
-   - Coverage targets: ≥95% lines, functions, branches, statements
-   - Fails if coverage targets not met
+   - Vitest unit suite execution (`pnpm test:unit`)
+   - Fails if unit tests fail
 
 6. **Install Playwright browsers**
 
@@ -226,7 +233,7 @@ trufflesecurity/trufflehog@main \
 
 10. **Upload coverage reports** (if always)
     ```yaml
-    uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
     with:
       name: coverage-report
       path: coverage/
@@ -245,9 +252,9 @@ trufflesecurity/trufflehog@main \
 
 **Permissions**: `contents: read`
 
-**Dependencies**: Requires both `quality` and `test` jobs to pass
+**Dependencies**: Requires `quality`, `test`, and `link-validation` jobs to pass
 
-**Conditional**: `if: always() && needs.quality.result == 'success' && needs.test.result == 'success'`
+**Conditional**: `if: always() && needs.quality.result == 'success' && needs.test.result == 'success' && needs.link-validation.result == 'success'`
 
 **Steps**:
 
@@ -278,6 +285,47 @@ trufflesecurity/trufflehog@main \
 
 **Outcome**: Fails if build fails; deployment blocked until all gates pass
 
+#### 5. Link-Validation Job
+
+**Purpose**: Validate registry integrity and run deterministic Playwright E2E coverage as a dedicated gate.
+
+**Runs on**: `ubuntu-latest`
+
+**Timeout**: 15 minutes
+
+**Permissions**: `contents: read`
+
+**Dependencies**: Requires `quality` job to pass
+
+**Key steps**:
+
+1. `pnpm install --frozen-lockfile`
+2. `pnpm registry:validate`
+3. Install Playwright browsers
+4. Start dev server + wait-on readiness
+5. `pnpm links:check` (maps to full Playwright E2E suite)
+
+**Outcome**: Fails if registry validation or Playwright E2E checks fail.
+
+#### 6. External Link Monitor Workflow (separate, non-blocking)
+
+**Workflow**: `external-link-monitor`
+
+**Job**: `check-external-evidence-links`
+
+**Triggers**:
+
+- Daily schedule (`20 9 * * *` UTC)
+- Manual dispatch (`workflow_dispatch`)
+
+**Command**:
+
+```bash
+pnpm links:check:external
+```
+
+**Design intent**: monitor live external URL reachability without adding third-party uptime dependencies to required PR merge checks.
+
 ## Build Blocking & Merge Gates
 
 ### GitHub Ruleset Configuration
@@ -289,8 +337,11 @@ trufflesecurity/trufflehog@main \
 ```
 - ci / quality
 - ci / test
+- ci / link-validation
 - ci / build
 ```
+
+Note: `external-link-monitor` is intentionally non-blocking and not listed as a required PR merge check.
 
 **Dismiss Stale PR Reviews**: False (reviewers' approvals invalidated by new commits)
 
@@ -406,6 +457,15 @@ pnpm test:e2e:ui  # Debug in interactive UI
 - Ensure dev server starts: `pnpm dev`
 - Check port 3000 availability
 - Increase wait-on timeout if needed
+
+### External Link Monitor Failures
+
+Because this workflow is non-blocking, failures should be triaged operationally:
+
+1. Re-run once to rule out transient outages.
+2. Validate failed URLs manually.
+3. Update registry evidence URLs when targets move.
+4. Track persistent upstream outages in issue/runbook workflow.
 
 ### Build Job Failures
 

--- a/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md
@@ -17,6 +17,7 @@ This runbook assumes Vercel and GitHub governance are already configured per [rb
 
 - `ci / quality` (lint, format:check, typecheck)
 - `ci / test` (unit tests, coverage, E2E tests)
+- `ci / link-validation` (registry validation + deterministic Playwright E2E gate)
 - `ci / build` (Next.js build)
 
 When any required check fails, this runbook provides deterministic diagnosis and fix procedures. See [rbk-portfolio-deploy.md](./rbk-portfolio-deploy.md) for the deploy workflow where CI gating is enforced.
@@ -82,6 +83,8 @@ Use this section when a dependency-automation update repeatedly fails CI for env
   - `pnpm test:unit`
   - `pnpm test:coverage`
   - `pnpm test:e2e`
+  - `pnpm links:check`
+  - `pnpm links:check:external`
 
 ## Procedure / Content
 
@@ -98,21 +101,25 @@ Use this section when a dependency-automation update repeatedly fails CI for env
 - `ci / build` job runs:
   - `pnpm install --frozen-lockfile`
   - `pnpm build`
-  - Playwright browser installation (`npx playwright install --with-deps`)
-  - Dev server startup (`pnpm dev &` + readiness check via `wait-on`)
-  - Smoke tests (`pnpm test` - 12 tests across Chromium + Firefox)
-  - depends on `ci / quality` being green
+  - depends on `ci / quality`, `ci / test`, and `ci / link-validation` being green
   - note: `secrets-scan` is not a strict dependency (only runs on PRs, but all PRs require it via branch protection)
 - `ci / test` job runs:
   - `pnpm test:unit`
   - `pnpm test:e2e`
   - uploads coverage artifacts from `pnpm test:coverage` when configured
+- `ci / link-validation` job runs:
+  - `pnpm registry:validate`
+  - Playwright install + dev server + readiness check
+  - `pnpm links:check` (full Playwright E2E suite)
+- `external-link-monitor` workflow runs separately:
+  - `pnpm links:check:external`
+  - scheduled + manual, non-blocking for PR merge
 
 ### 1) Identify the failing check and error class
 
 In the PR or `main` workflow run, identify:
 
-- failing job: `quality` or `build`
+- failing job: `quality`, `test`, `link-validation`, or `build`
 - failing step (lint vs format vs typecheck vs build)
 - affected file paths
 
@@ -139,7 +146,8 @@ pnpm lint
 pnpm format:check
 pnpm typecheck
 pnpm build
-pnpm test  # Smoke tests (Playwright)
+pnpm test:e2e
+pnpm links:check
 ```
 
 Use individual commands when you need to:
@@ -152,7 +160,7 @@ If local results differ from CI:
 
 - confirm Node and pnpm versions match project standards
 - ensure lockfile is committed and install is deterministic
-- for smoke test failures: ensure dev server is running (`pnpm dev`) or Playwright will start it automatically
+- for E2E/link-validation failures: ensure dev server is running (`pnpm dev`) or Playwright will start it automatically
 
 ### 3) Fix by failure type
 
@@ -254,9 +262,9 @@ pnpm build               # Expect: ✓ Compiled successfully
 - Clean and rebuild: `rm -rf .next node_modules/.cache && pnpm build`
 - Ensure `interpolate()` reads from `process.env` (fixed in commit `1a1e272`)
 
-#### E) Smoke test failures (`pnpm test`)
+#### E) Link-validation / E2E failures (`pnpm links:check` / `pnpm test:e2e`)
 
-Smoke tests are part of the current CI quality baseline.
+Deterministic Playwright checks are part of the required CI baseline.
 
 Symptoms:
 
@@ -281,17 +289,18 @@ Common failure modes:
    - Fix: Verify route exists and renders correctly locally
    - Check: Dynamic routes may need param fixes (Next.js 15 async params)
 
-4. **Evidence link resolution failures:**
+4. **Evidence link DOM assertion failures:**
    - Error: `a[href*="/docs/"]` locator not found
-   - Fix: Verify project pages include documentation links
-   - Check: `NEXT_PUBLIC_DOCS_BASE_URL` is configured correctly
+
+- Fix: Verify project pages include documentation links and non-empty href attributes
+- Check: `NEXT_PUBLIC_DOCS_BASE_URL` is configured correctly
 
 5. **Timeout failures:**
    - Error: Test timeout exceeded (default 30s per test)
    - Fix: Increase timeout in `playwright.config.ts` or optimize slow routes
    - CI: Reduce parallelism (already set to 1 worker in CI for stability)
 
-Debugging smoke tests:
+Debugging E2E/link-validation tests:
 
 ```bash
 # Local debugging
@@ -301,8 +310,26 @@ pnpm test:ui         # Opens Playwright UI mode
 # CI debugging
 # - Download HTML test report artifact from failed CI run
 # - Open playwright-report/index.html locally to see screenshots/traces
+```
 
-#### F) Unit test or coverage failures (`pnpm test:unit` / `pnpm test:coverage`)
+#### F) External monitor failures (`external-link-monitor` / `pnpm links:check:external`)
+
+This workflow is intentionally non-blocking for PR merges.
+
+Common causes:
+
+1. upstream docs or GitHub outage
+2. rate-limiting / anti-bot behavior
+3. URL changed in external system
+
+Response flow:
+
+1. re-run the workflow once to rule out transient noise
+2. verify failed URL manually
+3. if URL moved, update registry evidence URLs and re-run
+4. if upstream outage persists, track incident and avoid weakening required PR gates
+
+#### G) Unit test or coverage failures (`pnpm test:unit` / `pnpm test:coverage`)
 
 Symptoms:
 
@@ -314,14 +341,13 @@ Fix:
 - Run `pnpm test:unit` to reproduce and isolate the failing test
 - Run `pnpm test:coverage` to identify uncovered files or branches
 - Add or update unit tests for affected modules (pages, components, API handlers)
-```
 
 Fix workflow:
 
-- Reproduce locally with `pnpm test`
-- Check Playwright config (`playwright.config.ts`) for environment differences
-- Verify test file (`tests/e2e/smoke.spec.ts`) expectations match actual behavior
-- Update tests or fix routes as needed
+- Reproduce locally with `pnpm test:unit`
+- Use `pnpm test:coverage` to inspect uncovered areas
+- Verify failing unit test expectations against implementation behavior
+- Update tests or implementation with minimal scope
 - Re-run locally to confirm fix
 - Push and verify CI passes
 
@@ -356,7 +382,8 @@ pnpm lint
 pnpm format:check
 pnpm typecheck
 pnpm build
-pnpm test  # Smoke tests
+pnpm test:e2e
+pnpm links:check
 ```
 
 Commit and push to PR branch.
@@ -380,6 +407,8 @@ If the failure mode is likely to repeat:
 - Local and CI results converge (deterministic)
 - Required checks are green:
   - `ci / quality`
+  - `ci / test`
+  - `ci / link-validation`
   - `ci / build`
 - Production promotion proceeds once checks pass
 
@@ -400,7 +429,7 @@ If the fix is non-trivial and production is impacted:
   - reduce scope; fix incrementally; avoid mixing large refactors with feature changes
 
 - Merge is blocked because required checks are unavailable to select in the ruleset:
-  - ensure checks exist with the exact names `ci / quality` and `ci / build`
+  - ensure checks exist with the exact names `ci / quality`, `ci / test`, `ci / link-validation`, and `ci / build`
   - run the workflow on a PR and on `main` so GitHub can offer them as Required
 
 ### How to re-run checks

--- a/docs/50-operations/runbooks/rbk-portfolio-deploy.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-deploy.md
@@ -66,12 +66,11 @@ If suspected, stop and treat as an incident.
 - PR readiness:
   - PR template completed with security note (“No secrets added”)
   - Vercel preview exists and routes render (`/`, `/cv`, `/projects`, one project detail)
-  - Evidence links to docs resolve
+  - Evidence link UI is present and href values look correct
+  - Optional: external monitor reviewed (`external-link-monitor` workflow)
 - CI governance:
   - Required checks green: `ci / quality`, `ci / build`
   - Branch ruleset active (e.g., `main-protection`) and required checks selected
-
-### 1) Local preflight validation (required)
 
 ### 1) Local preflight validation (required)
 
@@ -79,15 +78,15 @@ If suspected, stop and treat as an incident.
 
 ```bash
 pnpm install
-pnpm verify  # Runs all 8 checks with detailed error reporting
+pnpm verify  # Runs the full local verification suite with detailed error reporting
 ```
 
-This runs: environment check, auto-format, format validation, lint, typecheck, audit, secret scanning, registry validation, build, and smoke tests.
+This runs: environment check, auto-format, format validation, lint, typecheck, audit, secret scanning, registry validation, build, performance checks, unit tests, and Playwright E2E checks.
 
 **Alternative: Quick validation (skip tests):**
 
 ```bash
-pnpm verify:quick  # Runs checks 1-7, skips smoke tests
+pnpm verify:quick  # Skips tests/performance for faster local iteration
 ```
 
 **Alternative: Manual step-by-step:**
@@ -102,7 +101,8 @@ pnpm typecheck         # TypeScript validation
 pnpm audit --audit-level=high  # Dependency vulnerability gate
 pnpm registry:validate # Projects YAML schema check
 pnpm build             # Production build
-pnpm test              # Smoke tests (Playwright - 12 tests)
+pnpm test:e2e          # Playwright E2E suite
+pnpm links:check       # Registry+E2E gate equivalent used by CI link-validation job
  # Secrets scanning runs in CI on PRs (TruffleHog). Local verify uses a lightweight pattern scan.
 ```
 
@@ -121,7 +121,7 @@ pnpm dev
 Expected outcome:
 
 - all commands succeed with no errors.
-- smoke tests: 12/12 passing (6 routes × 2 browsers)
+- Playwright E2E checks pass.
 
 ### 2) Open a PR (required)
 
@@ -142,7 +142,7 @@ In the PR:
   - `/cv` renders correctly
   - `/projects` renders list
   - at least one `/projects/[slug]` renders and includes evidence links
-- validate /docs links resolve correctly (path or subdomain)
+- validate /docs links target the expected host/path (path strategy or subdomain strategy)
 
 ### 4) Merge to `main`
 
@@ -190,9 +190,11 @@ git push origin staging
    - [ ] At least one project detail page renders (e.g., `/projects/portfolio-app`)
    - [ ] Contact page renders (`/contact`)
 3. Verify evidence links:
-   - [ ] Click "View Documentation" or similar links
-   - [ ] Verify links resolve to Documentation App
-   - [ ] Check that project dossier links work
+
+- [ ] Evidence link elements render with non-empty href values
+- [ ] Click sample links to sanity-check expected destinations
+- [ ] Optional: use external monitor for live connectivity confirmation
+
 4. Check browser console:
    - [ ] No JavaScript errors
    - [ ] No failed network requests
@@ -201,18 +203,21 @@ git push origin staging
 **Automated validation (recommended):**
 
 ```bash
-# Run Playwright smoke tests against staging
-PLAYWRIGHT_TEST_BASE_URL=https://staging-bns-portfolio.vercel.app pnpm playwright test
+# Run Playwright E2E tests against staging
+PLAYWRIGHT_TEST_BASE_URL=https://staging-bns-portfolio.vercel.app pnpm test:e2e
 
 # Or run specific test file
-PLAYWRIGHT_TEST_BASE_URL=https://staging-bns-portfolio.vercel.app pnpm playwright test tests/smoke.spec.ts
+PLAYWRIGHT_TEST_BASE_URL=https://staging-bns-portfolio.vercel.app pnpm test:e2e:single
+
+# Optional: run live external link monitor (non-blocking)
+pnpm links:check:external
 ```
 
 **Expected outcome:**
 
 - All manual checks pass
 - Automated tests pass (if running)
-- No console errors or broken links
+- No console errors; external-link monitor results reviewed when connectivity confidence is required
 
 **If staging validation fails:**
 
@@ -245,8 +250,10 @@ PLAYWRIGHT_TEST_BASE_URL=https://staging-bns-portfolio.vercel.app pnpm playwrigh
 1. Open `https://bns-portfolio.vercel.app` in browser
 2. Verify same critical paths as staging:
    - [ ] Home, CV, Projects, Contact pages render
-   - [ ] Evidence links resolve correctly
-   - [ ] No console errors
+
+- [ ] Evidence links render correctly and navigate to expected destinations
+- [ ] No console errors
+
 3. **Compare with staging:**
    - [ ] Production behavior matches staging validation
    - [ ] No unexpected differences
@@ -303,8 +310,8 @@ Expected outcome:
 From the deployed environment (Preview or Production), validate behavior that depends on env:
 
 - Documentation link(s) resolve correctly:
-  - clicking “Docs” or “Evidence” navigates to the Documentation App host derived from `NEXT_PUBLIC_DOCS_BASE_URL`
-- Profile links resolve correctly:
+  - clicking “Docs” or “Evidence” navigates to the Documentation App host/path derived from `NEXT_PUBLIC_DOCS_BASE_URL`
+- Profile links navigate correctly:
   - GitHub/LinkedIn links (if present) go to the configured destinations
 - Optional mail link:
   - contact email (if configured) generates a correct `mailto:` link
@@ -320,7 +327,7 @@ If validation fails:
 Validate production:
 
 - core routes load (same set as preview)
-- evidence links to docs remain correct
+- evidence links to docs remain correct in UI and destination expectations
 - no broken images/assets
 
 ### 10) Record release evidence (recommended)
@@ -430,7 +437,9 @@ For detailed rollback procedures, see [rbk-portfolio-rollback.md](./rbk-portfoli
 - Promotion stuck “waiting for checks”:
   - ensure CI runs on push to main; confirm check names match imported checks
 - Broken evidence links:
-  - treat as regression; fix forward or rollback depending on severity
+  - distinguish between app-side regression (broken href/render) and external outage (monitor alert)
+  - app-side regression: treat as release blocker; fix forward or rollback
+  - external outage only: track operationally; do not weaken deterministic PR gates
 
 ## References
 

--- a/docs/60-projects/portfolio-app/01-overview.md
+++ b/docs/60-projects/portfolio-app/01-overview.md
@@ -279,8 +279,8 @@ The GitHub Actions workflow orchestrates quality gates with job dependencies:
 quality (lint, format, typecheck, audit)
   ↓
 test (unit + E2E)
-  ↓
-link-validation (registry + evidence links)
+  ↘
+link-validation (registry + deterministic Playwright E2E)
   ↓
 build (Next.js compile + deployment gate)
 
@@ -290,7 +290,7 @@ PR-only: secrets-scan (TruffleHog)
 All jobs must pass; failures block subsequent stages. Tests are separated into distinct steps for clarity:
 
 - **Unit tests** validate data integrity, link construction, and slug validation
-- **E2E tests** validate route rendering, evidence link resolution, and component behavior
+- **E2E tests** validate route rendering, evidence-link DOM/href assertions, and component behavior
 
 See [CI/CD Pipeline Overview](/docs/devops-platform/ci-cd-pipeline-overview) for detailed job configuration and troubleshooting.
 

--- a/docs/60-projects/portfolio-app/03-deployment.md
+++ b/docs/60-projects/portfolio-app/03-deployment.md
@@ -100,7 +100,7 @@ The Portfolio App operates across three tiers, each serving a distinct purpose i
 - **Domain:** Auto-generated Vercel URL per PR (e.g., `portfolio-app-git-feat-xyz.vercel.app`)
 - **Validation:**
   - Reviewers validate routing, rendering, and functionality
-  - Evidence links to Documentation App are verified
+  - Evidence links to Documentation App are rendered with expected destinations
   - CI checks run automatically
 
 ### Staging (`staging` branch)
@@ -110,7 +110,7 @@ The Portfolio App operates across three tiers, each serving a distinct purpose i
 - **Domain:** `https://staging-bns-portfolio.vercel.app`
 - **Validation:**
   - Full smoke test suite against staging URL
-  - Evidence link resolution and navigation flow verification
+  - Evidence link rendering/destination verification and navigation flow checks
   - Performance and accessibility spot checks
   - Manual exploratory testing for critical paths
 

--- a/docs/60-projects/portfolio-app/05-testing.md
+++ b/docs/60-projects/portfolio-app/05-testing.md
@@ -280,7 +280,7 @@ Note: This section distinguishes baseline controls from expanded controls for on
 
 ### Expanded coverage: Automated E2E tests with Playwright
 
-Playwright coverage includes evidence link resolution and route-level verification as part of the current baseline.
+Playwright coverage includes evidence-link DOM/href assertions and route-level verification as part of the current baseline.
 
 **Framework:** Playwright (multi-browser E2E testing)
 
@@ -318,6 +318,14 @@ pnpm exec playwright show-report    # View HTML test report
 
 - Tests run in `ci / test` job before build
 - Playwright browsers installed via `npx playwright install --with-deps`
+
+### External evidence-link monitor (non-blocking)
+
+- Workflow: `external-link-monitor`
+- Command: `pnpm links:check:external`
+- Trigger: daily schedule + manual dispatch
+- Purpose: best-effort live HTTP reachability checks for external evidence URLs
+- Governance: non-blocking for PR merge gates to avoid third-party uptime flakiness
 - Dev server started with `pnpm dev &` and readiness check via `wait-on http://localhost:3000`
 - Tests execute with `pnpm test:e2e`
 - HTML test reports generated (`.gitignored`)

--- a/docs/60-projects/portfolio-app/06-operations.md
+++ b/docs/60-projects/portfolio-app/06-operations.md
@@ -148,7 +148,8 @@ Responsibilities:
   - E2E tests: `pnpm test:e2e` (Playwright suite across Chromium and Firefox)
 - Link validation runs:
   - Registry validation: `pnpm registry:validate` (checks project metadata schema)
-  - Evidence link checks: `pnpm links:check` (Playwright smoke tests)
+  - Deterministic E2E gate: `pnpm links:check` (full Playwright E2E suite)
+  - Live external monitor: `pnpm links:check:external` (scheduled/manual, non-blocking)
   - Produces playwright-report artifact on failure for diagnostic use
 - Build runs `pnpm build` with frozen lockfile installs, then triggers Vercel deployment
 - If CI fails: follow the CI triage runbook: [docs/50-operations/runbooks/rbk-portfolio-ci-triage.md](docs/50-operations/runbooks/rbk-portfolio-ci-triage.md).
@@ -159,7 +160,7 @@ Responsibilities:
 - **Required before production is considered complete**
 - Validation includes:
   - Manual smoke tests of critical routes (`/`, `/cv`, `/projects`, `/contact`)
-  - Evidence link resolution verification
+  - Evidence link rendering and expected-destination verification
   - Browser console error checks
   - Optional automated Playwright tests via: `PLAYWRIGHT_TEST_BASE_URL=https://staging-bns-portfolio.vercel.app pnpm test:e2e`
 - If staging validation fails: fix via hotfix PR or rollback (see [rbk-portfolio-deploy.md](docs/50-operations/runbooks/rbk-portfolio-deploy.md))

--- a/docs/70-reference/testing-guide.md
+++ b/docs/70-reference/testing-guide.md
@@ -12,7 +12,8 @@ This guide provides patterns and examples for writing tests in the Portfolio App
 ## Scope
 
 - Unit testing patterns with Vitest (registry validation, slug helpers, link construction)
-- E2E testing patterns with Playwright (component rendering, link resolution)
+- E2E testing patterns with Playwright (component rendering, route/API behavior, evidence-link DOM assertions)
+- Live external evidence-link monitoring patterns (best-effort HTTP reachability checks)
 - Running tests locally and in CI
 - Interpreting test output and coverage reports
 - Troubleshooting common test failures
@@ -26,15 +27,15 @@ The Portfolio App follows a testing pyramid: broad unit tests at the base, fewer
 ```mermaid
 graph TB
     subgraph E2E["E2E Tests (Playwright) - ~66 tests"]
-        E1["Evidence link resolution"]
+    E1["Evidence link DOM/href validation"]
         E2["Component rendering"]
         E3["Route coverage (user journeys)"]
         E4["Responsive design"]
     end
 
-    subgraph INT["Integration Tests (Future)"]
-        I1["API routes"]
-        I2["Data fetching"]
+  subgraph INT["Integration Monitor (External)"]
+    I1["Live HTTP checks (docs/github URLs)"]
+    I2["Scheduled + manual non-blocking workflow"]
     end
 
     subgraph UNIT["Unit Tests (Vitest)"]
@@ -498,7 +499,29 @@ test('echo endpoint rate limits repeated requests', async ({ request }) => {
 6. Responsive checks (mobile/tablet/desktop) for evidence content
 7. Security endpoints (`/api/csrf`, `/api/echo`) and CSP nonce headers
 
-### Evidence Link Resolution Tests (optional enhancement)
+Important behavior note:
+
+- Playwright E2E tests verify evidence link DOM presence and non-empty href attributes.
+- Playwright E2E tests do not perform remote connectivity checks against external docs or GitHub hosts.
+
+### External Evidence Link Monitor
+
+Use the external monitor for live reachability of external evidence URLs.
+
+- Local/manual command: `pnpm links:check:external`
+- CI workflow: `.github/workflows/external-link-monitor.yml`
+- Trigger modes:
+  - scheduled (`20 9 * * *`, daily UTC)
+  - manual (`workflow_dispatch`)
+- Scope:
+  - checks absolute http/https evidence URLs from the registry
+  - uses `HEAD` first with `GET` fallback for common server restrictions
+  - retries transient failures and reports a pass/fail summary
+- Governance:
+  - non-blocking by design for PR merge gates
+  - used for monitoring and triage, not deterministic merge blocking
+
+### Evidence Link Rendering Tests (optional enhancement)
 
 **Recommended additions**:
 
@@ -512,7 +535,7 @@ test('echo endpoint rate limits repeated requests', async ({ request }) => {
 ```typescript
 import { test, expect } from '@playwright/test';
 
-test.describe('Evidence Link Resolution', () => {
+test.describe('Evidence Link Rendering', () => {
   test('portfolio-app project page renders', async ({ page }) => {
     await page.goto('/projects/portfolio-app');
 
@@ -660,6 +683,17 @@ This ensures:
 2. Merge is blocked if CI fails
 3. Coverage reports are available for review
 
+### External Link Monitor Workflow (non-blocking)
+
+The Portfolio App also includes a separate workflow for live external evidence-link checks:
+
+- Workflow: `external-link-monitor`
+- Job: `check-external-evidence-links`
+- Trigger: schedule + manual dispatch
+- Command: `pnpm links:check:external`
+
+This workflow is intentionally separate from required PR checks to avoid flaky merges caused by third-party outages, anti-bot controls, or transient network conditions.
+
 ## Troubleshooting
 
 For CI check failures and coverage gate triage, see [docs/50-operations/runbooks/rbk-portfolio-ci-triage.md](docs/50-operations/runbooks/rbk-portfolio-ci-triage.md).
@@ -707,6 +741,17 @@ await expect(page.locator('text=Evidence Artifacts')).toBeVisible();
 **Problem**: Tests pass individually but fail when run together
 
 **Solution**: Ensure tests clean up state (clear cookies, logout). Use `test.beforeEach()` and `test.afterEach()` for setup/teardown.
+
+### External Monitor Failures
+
+**Problem**: `external-link-monitor` reports failed external URLs
+
+**Solution**:
+
+1. Re-run once to rule out transient network/provider issues.
+2. If failure persists, verify the URL in browser or with curl.
+3. If URL moved or was removed, update registry evidence data.
+4. If upstream host is degraded, track via issue/runbook and avoid destabilizing PR gates.
 
 ### Coverage Issues
 


### PR DESCRIPTION
## Summary
This updates testing, CI/CD, runbook, and portfolio-app dossier documentation to accurately reflect current behavior:
- Deterministic PR gates (`ci / quality`, `ci / test`, `ci / link-validation`, `ci / build`)
- `links:check` as deterministic Playwright/registry gate
- `links:check:external` + `external-link-monitor` as scheduled/manual, non-blocking live monitoring
- Clarified wording from implied external "resolution" to DOM/href validation where applicable

## Files updated
- `docs/70-reference/testing-guide.md`
- `docs/30-devops-platform/ci-cd-pipeline-overview.md`
- `docs/50-operations/runbooks/rbk-portfolio-ci-triage.md`
- `docs/50-operations/runbooks/rbk-portfolio-deploy.md`
- `docs/00-portfolio/features/02-evidence-first-content-model/evidence-linking.md`
- `docs/00-portfolio/features/01-core-pages-reviewer-journey/cv-page.md`
- `docs/60-projects/portfolio-app/01-overview.md`
- `docs/60-projects/portfolio-app/03-deployment.md`
- `docs/60-projects/portfolio-app/05-testing.md`
- `docs/60-projects/portfolio-app/06-operations.md`
- `docs/10-architecture/adr/adr-0012-cross-repo-documentation-linking.md`

## Validation
- `pnpm verify:quick` passed locally in `portfolio-docs`

## Notes
Documentation-only changes. No runtime code changes.