### PR TITLE
fix: resolve Vercel deploy failures from /docs internal link prefixes

### DIFF
--- a/docs/00-portfolio/features/01-core-pages-reviewer-journey/contact-page.md
+++ b/docs/00-portfolio/features/01-core-pages-reviewer-journey/contact-page.md
@@ -83,8 +83,8 @@ tags: [portfolio, features, core-pages, contact]
 
 ### Additional internal references
 
-- [`/40-security/security-policies.md`](/docs/40-security/security-policies.md)
-- [`/70-reference/portfolio-app-config-reference.md`](/docs/70-reference/portfolio-app-config-reference.md)
+- [`/40-security/security-policies.md`](/40-security/security-policies.md)
+- [`/70-reference/portfolio-app-config-reference.md`](/70-reference/portfolio-app-config-reference.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/01-core-pages-reviewer-journey/cv-page.md
+++ b/docs/00-portfolio/features/01-core-pages-reviewer-journey/cv-page.md
@@ -86,8 +86,8 @@ tags: [portfolio, features, core-pages, cv]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
-- [`/70-reference/evidence-audit-checklist.md`](/docs/70-reference/evidence-audit-checklist.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
+- [`/70-reference/evidence-audit-checklist.md`](/70-reference/evidence-audit-checklist.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/01-core-pages-reviewer-journey/landing-page.md
+++ b/docs/00-portfolio/features/01-core-pages-reviewer-journey/landing-page.md
@@ -93,8 +93,8 @@ tags: [portfolio, features, core-pages, landing]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
-- [`/70-reference/portfolio-app-config-reference.md`](/docs/70-reference/portfolio-app-config-reference.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
+- [`/70-reference/portfolio-app-config-reference.md`](/70-reference/portfolio-app-config-reference.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/01-core-pages-reviewer-journey/project-detail-page.md
+++ b/docs/00-portfolio/features/01-core-pages-reviewer-journey/project-detail-page.md
@@ -86,7 +86,7 @@ tags: [portfolio, features, core-pages, project-detail]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0011-data-driven-project-registry.md`](/docs/10-architecture/adr/adr-0011-data-driven-project-registry.md)
+- [`/10-architecture/adr/adr-0011-data-driven-project-registry.md`](/10-architecture/adr/adr-0011-data-driven-project-registry.md)
 
 ### Runbooks
 
@@ -94,9 +94,9 @@ tags: [portfolio, features, core-pages, project-detail]
 
 ### Additional internal references
 
-- [`/70-reference/registry-schema-guide.md`](/docs/70-reference/registry-schema-guide.md)
-- [`/70-reference/seo-metadata-guide.md`](/docs/70-reference/seo-metadata-guide.md)
-- [`/70-reference/testing-guide.md`](/docs/70-reference/testing-guide.md)
+- [`/70-reference/registry-schema-guide.md`](/70-reference/registry-schema-guide.md)
+- [`/70-reference/seo-metadata-guide.md`](/70-reference/seo-metadata-guide.md)
+- [`/70-reference/testing-guide.md`](/70-reference/testing-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/01-core-pages-reviewer-journey/projects-gallery.md
+++ b/docs/00-portfolio/features/01-core-pages-reviewer-journey/projects-gallery.md
@@ -80,7 +80,7 @@ tags: [portfolio, features, core-pages, projects]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0011-data-driven-project-registry.md`](/docs/10-architecture/adr/adr-0011-data-driven-project-registry.md)
+- [`/10-architecture/adr/adr-0011-data-driven-project-registry.md`](/10-architecture/adr/adr-0011-data-driven-project-registry.md)
 
 ### Runbooks
 
@@ -88,8 +88,8 @@ tags: [portfolio, features, core-pages, projects]
 
 ### Additional internal references
 
-- [`/70-reference/registry-schema-guide.md`](/docs/70-reference/registry-schema-guide.md)
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/70-reference/registry-schema-guide.md`](/70-reference/registry-schema-guide.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/02-evidence-first-content-model/evidence-linking.md
+++ b/docs/00-portfolio/features/02-evidence-first-content-model/evidence-linking.md
@@ -87,8 +87,8 @@ tags: [portfolio, features, evidence, links]
 
 ### Additional internal references
 
-- [`/70-reference/portfolio-app-config-reference.md`](/docs/70-reference/portfolio-app-config-reference.md)
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/70-reference/portfolio-app-config-reference.md`](/70-reference/portfolio-app-config-reference.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/02-evidence-first-content-model/evidence-visualization.md
+++ b/docs/00-portfolio/features/02-evidence-first-content-model/evidence-visualization.md
@@ -86,8 +86,8 @@ tags: [portfolio, features, evidence, components]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
-- [`/70-reference/registry-schema-guide.md`](/docs/70-reference/registry-schema-guide.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
+- [`/70-reference/registry-schema-guide.md`](/70-reference/registry-schema-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/02-evidence-first-content-model/project-registry.md
+++ b/docs/00-portfolio/features/02-evidence-first-content-model/project-registry.md
@@ -81,7 +81,7 @@ tags: [portfolio, features, evidence, registry]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0011-data-driven-project-registry.md`](/docs/10-architecture/adr/adr-0011-data-driven-project-registry.md)
+- [`/10-architecture/adr/adr-0011-data-driven-project-registry.md`](/10-architecture/adr/adr-0011-data-driven-project-registry.md)
 
 ### Runbooks
 
@@ -89,8 +89,8 @@ tags: [portfolio, features, evidence, registry]
 
 ### Additional internal references
 
-- [`/70-reference/registry-schema-guide.md`](/docs/70-reference/registry-schema-guide.md)
-- [`/70-reference/testing-guide.md`](/docs/70-reference/testing-guide.md)
+- [`/70-reference/registry-schema-guide.md`](/70-reference/registry-schema-guide.md)
+- [`/70-reference/testing-guide.md`](/70-reference/testing-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/03-navigation-ux-polish/back-to-top.md
+++ b/docs/00-portfolio/features/03-navigation-ux-polish/back-to-top.md
@@ -82,7 +82,7 @@ tags: [portfolio, features, navigation, ux]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/03-navigation-ux-polish/layout-primitives.md
+++ b/docs/00-portfolio/features/03-navigation-ux-polish/layout-primitives.md
@@ -82,7 +82,7 @@ tags: [portfolio, features, navigation, ux]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/03-navigation-ux-polish/navigation-header.md
+++ b/docs/00-portfolio/features/03-navigation-ux-polish/navigation-header.md
@@ -87,7 +87,7 @@ tags: [portfolio, features, navigation, header]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/03-navigation-ux-polish/scroll-animations.md
+++ b/docs/00-portfolio/features/03-navigation-ux-polish/scroll-animations.md
@@ -75,7 +75,7 @@ tags: [portfolio, features, navigation, ux]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0016-scroll-animations.md`](/docs/10-architecture/adr/adr-0016-scroll-animations.md)
+- [`/10-architecture/adr/adr-0016-scroll-animations.md`](/10-architecture/adr/adr-0016-scroll-animations.md)
 
 ### Runbooks
 
@@ -83,8 +83,8 @@ tags: [portfolio, features, navigation, ux]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
-- [`/70-reference/theme-system-reference.md`](/docs/70-reference/theme-system-reference.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
+- [`/70-reference/theme-system-reference.md`](/70-reference/theme-system-reference.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/04-theming-accessibility/reduced-motion.md
+++ b/docs/00-portfolio/features/04-theming-accessibility/reduced-motion.md
@@ -73,7 +73,7 @@ tags: [portfolio, features, theming, accessibility]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0016-scroll-animations.md`](/docs/10-architecture/adr/adr-0016-scroll-animations.md)
+- [`/10-architecture/adr/adr-0016-scroll-animations.md`](/10-architecture/adr/adr-0016-scroll-animations.md)
 
 ### Runbooks
 
@@ -81,8 +81,8 @@ tags: [portfolio, features, theming, accessibility]
 
 ### Additional internal references
 
-- [`/70-reference/theme-system-reference.md`](/docs/70-reference/theme-system-reference.md)
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/70-reference/theme-system-reference.md`](/70-reference/theme-system-reference.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/04-theming-accessibility/theme-initialization.md
+++ b/docs/00-portfolio/features/04-theming-accessibility/theme-initialization.md
@@ -73,7 +73,7 @@ tags: [portfolio, features, theming, accessibility]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0014-class-based-dark-mode.md`](/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md)
+- [`/10-architecture/adr/adr-0014-class-based-dark-mode.md`](/10-architecture/adr/adr-0014-class-based-dark-mode.md)
 
 ### Runbooks
 
@@ -81,7 +81,7 @@ tags: [portfolio, features, theming, accessibility]
 
 ### Additional internal references
 
-- [`/70-reference/theme-system-reference.md`](/docs/70-reference/theme-system-reference.md)
+- [`/70-reference/theme-system-reference.md`](/70-reference/theme-system-reference.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/04-theming-accessibility/theme-system.md
+++ b/docs/00-portfolio/features/04-theming-accessibility/theme-system.md
@@ -75,7 +75,7 @@ tags: [portfolio, features, theming, accessibility]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0014-class-based-dark-mode.md`](/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md)
+- [`/10-architecture/adr/adr-0014-class-based-dark-mode.md`](/10-architecture/adr/adr-0014-class-based-dark-mode.md)
 
 ### Runbooks
 
@@ -83,8 +83,8 @@ tags: [portfolio, features, theming, accessibility]
 
 ### Additional internal references
 
-- [`/70-reference/theme-system-reference.md`](/docs/70-reference/theme-system-reference.md)
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/70-reference/theme-system-reference.md`](/70-reference/theme-system-reference.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/04-theming-accessibility/theme-toggle.md
+++ b/docs/00-portfolio/features/04-theming-accessibility/theme-toggle.md
@@ -75,7 +75,7 @@ tags: [portfolio, features, theming, accessibility]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0014-class-based-dark-mode.md`](/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md)
+- [`/10-architecture/adr/adr-0014-class-based-dark-mode.md`](/10-architecture/adr/adr-0014-class-based-dark-mode.md)
 
 ### Runbooks
 
@@ -83,8 +83,8 @@ tags: [portfolio, features, theming, accessibility]
 
 ### Additional internal references
 
-- [`/70-reference/theme-system-reference.md`](/docs/70-reference/theme-system-reference.md)
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/70-reference/theme-system-reference.md`](/70-reference/theme-system-reference.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/05-seo-metadata-structured-data/metadata-baseline.md
+++ b/docs/00-portfolio/features/05-seo-metadata-structured-data/metadata-baseline.md
@@ -75,7 +75,7 @@ tags: [portfolio, features, seo, metadata]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0015-metadata-strategy.md`](/docs/10-architecture/adr/adr-0015-metadata-strategy.md)
+- [`/10-architecture/adr/adr-0015-metadata-strategy.md`](/10-architecture/adr/adr-0015-metadata-strategy.md)
 
 ### Runbooks
 
@@ -83,8 +83,8 @@ tags: [portfolio, features, seo, metadata]
 
 ### Additional internal references
 
-- [`/70-reference/seo-metadata-guide.md`](/docs/70-reference/seo-metadata-guide.md)
-- [`/70-reference/social-metadata-guide.md`](/docs/70-reference/social-metadata-guide.md)
+- [`/70-reference/seo-metadata-guide.md`](/70-reference/seo-metadata-guide.md)
+- [`/70-reference/social-metadata-guide.md`](/70-reference/social-metadata-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/05-seo-metadata-structured-data/structured-data.md
+++ b/docs/00-portfolio/features/05-seo-metadata-structured-data/structured-data.md
@@ -75,7 +75,7 @@ tags: [portfolio, features, seo, structured-data]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0015-metadata-strategy.md`](/docs/10-architecture/adr/adr-0015-metadata-strategy.md)
+- [`/10-architecture/adr/adr-0015-metadata-strategy.md`](/10-architecture/adr/adr-0015-metadata-strategy.md)
 
 ### Runbooks
 
@@ -83,8 +83,8 @@ tags: [portfolio, features, seo, structured-data]
 
 ### Additional internal references
 
-- [`/70-reference/seo-metadata-guide.md`](/docs/70-reference/seo-metadata-guide.md)
-- [`/70-reference/social-metadata-guide.md`](/docs/70-reference/social-metadata-guide.md)
+- [`/70-reference/seo-metadata-guide.md`](/70-reference/seo-metadata-guide.md)
+- [`/70-reference/social-metadata-guide.md`](/70-reference/social-metadata-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/06-security-posture-hardening/secrets-hygiene.md
+++ b/docs/00-portfolio/features/06-security-posture-hardening/secrets-hygiene.md
@@ -80,12 +80,12 @@ tags: [portfolio, features, security, secrets]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-secrets-incident.md`](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)
+- [`/50-operations/runbooks/rbk-portfolio-secrets-incident.md`](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)
 
 ### Additional internal references
 
-- [`/40-security/security-policies.md`](/docs/40-security/security-policies.md)
-- [`/70-reference/portfolio-app-config-reference.md`](/docs/70-reference/portfolio-app-config-reference.md)
+- [`/40-security/security-policies.md`](/40-security/security-policies.md)
+- [`/70-reference/portfolio-app-config-reference.md`](/70-reference/portfolio-app-config-reference.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/06-security-posture-hardening/security-headers.md
+++ b/docs/00-portfolio/features/06-security-posture-hardening/security-headers.md
@@ -85,8 +85,8 @@ tags: [portfolio, features, security, headers]
 
 ### Additional internal references
 
-- [`/40-security/portfolio-app-security-controls.md`](/docs/40-security/portfolio-app-security-controls.md)
-- [`/40-security/security-policies.md`](/docs/40-security/security-policies.md)
+- [`/40-security/portfolio-app-security-controls.md`](/40-security/portfolio-app-security-controls.md)
+- [`/40-security/security-policies.md`](/40-security/security-policies.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/06-security-posture-hardening/supply-chain-security.md
+++ b/docs/00-portfolio/features/06-security-posture-hardening/supply-chain-security.md
@@ -82,12 +82,12 @@ tags: [portfolio, features, security, supply-chain]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md`](/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)
+- [`/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md`](/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)
 
 ### Additional internal references
 
-- [`/40-security/security-policies.md`](/docs/40-security/security-policies.md)
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/40-security/security-policies.md`](/40-security/security-policies.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/07-testing-quality-gates/ci-quality-gates.md
+++ b/docs/00-portfolio/features/07-testing-quality-gates/ci-quality-gates.md
@@ -87,12 +87,12 @@ tags: [portfolio, features, testing, quality]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ### Additional internal references
 
-- [`/70-reference/testing-guide.md`](/docs/70-reference/testing-guide.md)
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/70-reference/testing-guide.md`](/70-reference/testing-guide.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/07-testing-quality-gates/e2e-testing.md
+++ b/docs/00-portfolio/features/07-testing-quality-gates/e2e-testing.md
@@ -86,13 +86,13 @@ tags: [portfolio, features, testing, e2e]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
-- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/50-operations/runbooks/rbk-portfolio-deploy.md)
+- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ### Additional internal references
 
-- [`/70-reference/testing-guide.md`](/docs/70-reference/testing-guide.md)
-- [`/30-devops-platform/observability-health-checks.md`](/docs/30-devops-platform/observability-health-checks.md)
+- [`/70-reference/testing-guide.md`](/70-reference/testing-guide.md)
+- [`/30-devops-platform/observability-health-checks.md`](/30-devops-platform/observability-health-checks.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/07-testing-quality-gates/local-verification.md
+++ b/docs/00-portfolio/features/07-testing-quality-gates/local-verification.md
@@ -81,11 +81,11 @@ tags: [portfolio, features, testing, verification]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ### Additional internal references
 
-- [`/70-reference/testing-guide.md`](/docs/70-reference/testing-guide.md)
+- [`/70-reference/testing-guide.md`](/70-reference/testing-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/07-testing-quality-gates/unit-testing.md
+++ b/docs/00-portfolio/features/07-testing-quality-gates/unit-testing.md
@@ -88,11 +88,11 @@ tags: [portfolio, features, testing, unit]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [`/50-operations/runbooks/rbk-portfolio-ci-triage.md`](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ### Additional internal references
 
-- [`/70-reference/testing-guide.md`](/docs/70-reference/testing-guide.md)
+- [`/70-reference/testing-guide.md`](/70-reference/testing-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/08-cicd-environment-promotion/preview-deployments.md
+++ b/docs/00-portfolio/features/08-cicd-environment-promotion/preview-deployments.md
@@ -74,15 +74,15 @@ tags: [portfolio, features, cicd, deployments]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/docs/10-architecture/adr/adr-0013-multi-environment-deployment.md)
+- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/10-architecture/adr/adr-0013-multi-environment-deployment.md)
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
+- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/50-operations/runbooks/rbk-portfolio-deploy.md)
 
 ### Additional internal references
 
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/08-cicd-environment-promotion/production-promotion.md
+++ b/docs/00-portfolio/features/08-cicd-environment-promotion/production-promotion.md
@@ -75,16 +75,16 @@ tags: [portfolio, features, cicd, production]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/docs/10-architecture/adr/adr-0013-multi-environment-deployment.md)
+- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/10-architecture/adr/adr-0013-multi-environment-deployment.md)
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
-- [`/50-operations/runbooks/rbk-portfolio-rollback.md`](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
+- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/50-operations/runbooks/rbk-portfolio-deploy.md)
+- [`/50-operations/runbooks/rbk-portfolio-rollback.md`](/50-operations/runbooks/rbk-portfolio-rollback.md)
 
 ### Additional internal references
 
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/08-cicd-environment-promotion/rollback-workflow.md
+++ b/docs/00-portfolio/features/08-cicd-environment-promotion/rollback-workflow.md
@@ -74,15 +74,15 @@ tags: [portfolio, features, cicd, rollback]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/docs/10-architecture/adr/adr-0013-multi-environment-deployment.md)
+- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/10-architecture/adr/adr-0013-multi-environment-deployment.md)
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-rollback.md`](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
+- [`/50-operations/runbooks/rbk-portfolio-rollback.md`](/50-operations/runbooks/rbk-portfolio-rollback.md)
 
 ### Additional internal references
 
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/08-cicd-environment-promotion/staging-promotion.md
+++ b/docs/00-portfolio/features/08-cicd-environment-promotion/staging-promotion.md
@@ -74,16 +74,16 @@ tags: [portfolio, features, cicd, staging]
 
 ### ADRs
 
-- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/docs/10-architecture/adr/adr-0013-multi-environment-deployment.md)
+- [`/10-architecture/adr/adr-0013-multi-environment-deployment.md`](/10-architecture/adr/adr-0013-multi-environment-deployment.md)
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
-- [`/50-operations/runbooks/rbk-portfolio-environment-promotion.md`](/docs/50-operations/runbooks/rbk-portfolio-environment-promotion.md)
+- [`/50-operations/runbooks/rbk-portfolio-deploy.md`](/50-operations/runbooks/rbk-portfolio-deploy.md)
+- [`/50-operations/runbooks/rbk-portfolio-environment-promotion.md`](/50-operations/runbooks/rbk-portfolio-environment-promotion.md)
 
 ### Additional internal references
 
-- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- [`/30-devops-platform/ci-cd-pipeline-overview.md`](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/09-performance-observability/analytics-monitoring.md
+++ b/docs/00-portfolio/features/09-performance-observability/analytics-monitoring.md
@@ -81,7 +81,7 @@ tags: [portfolio, features, observability, analytics]
 
 ### Additional internal references
 
-- [`/30-devops-platform/observability-health-checks.md`](/docs/30-devops-platform/observability-health-checks.md)
+- [`/30-devops-platform/observability-health-checks.md`](/30-devops-platform/observability-health-checks.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/09-performance-observability/bundle-size-regression.md
+++ b/docs/00-portfolio/features/09-performance-observability/bundle-size-regression.md
@@ -77,11 +77,11 @@ tags: [portfolio, features, performance, bundle]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-performance-optimization.md`](/docs/50-operations/runbooks/rbk-portfolio-performance-optimization.md)
+- [`/50-operations/runbooks/rbk-portfolio-performance-optimization.md`](/50-operations/runbooks/rbk-portfolio-performance-optimization.md)
 
 ### Additional internal references
 
-- [`/70-reference/performance-optimization-guide.md`](/docs/70-reference/performance-optimization-guide.md)
+- [`/70-reference/performance-optimization-guide.md`](/70-reference/performance-optimization-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/09-performance-observability/health-endpoint.md
+++ b/docs/00-portfolio/features/09-performance-observability/health-endpoint.md
@@ -76,11 +76,11 @@ tags: [portfolio, features, observability, health]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-service-degradation.md`](/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md)
+- [`/50-operations/runbooks/rbk-portfolio-service-degradation.md`](/50-operations/runbooks/rbk-portfolio-service-degradation.md)
 
 ### Additional internal references
 
-- [`/30-devops-platform/observability-health-checks.md`](/docs/30-devops-platform/observability-health-checks.md)
+- [`/30-devops-platform/observability-health-checks.md`](/30-devops-platform/observability-health-checks.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/09-performance-observability/isr-caching.md
+++ b/docs/00-portfolio/features/09-performance-observability/isr-caching.md
@@ -77,11 +77,11 @@ tags: [portfolio, features, performance, caching]
 
 ### Runbooks
 
-- [`/50-operations/runbooks/rbk-portfolio-performance-optimization.md`](/docs/50-operations/runbooks/rbk-portfolio-performance-optimization.md)
+- [`/50-operations/runbooks/rbk-portfolio-performance-optimization.md`](/50-operations/runbooks/rbk-portfolio-performance-optimization.md)
 
 ### Additional internal references
 
-- [`/70-reference/performance-optimization-guide.md`](/docs/70-reference/performance-optimization-guide.md)
+- [`/70-reference/performance-optimization-guide.md`](/70-reference/performance-optimization-guide.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/10-docs-governance-integration/evidence-links.md
+++ b/docs/00-portfolio/features/10-docs-governance-integration/evidence-links.md
@@ -86,8 +86,8 @@ tags: [portfolio, features, documentation, evidence]
 
 ### Additional internal references
 
-- [`/70-reference/registry-schema-guide.md`](/docs/70-reference/registry-schema-guide.md)
-- [`/70-reference/portfolio-app-config-reference.md`](/docs/70-reference/portfolio-app-config-reference.md)
+- [`/70-reference/registry-schema-guide.md`](/70-reference/registry-schema-guide.md)
+- [`/70-reference/portfolio-app-config-reference.md`](/70-reference/portfolio-app-config-reference.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/features/10-docs-governance-integration/reviewer-guidance.md
+++ b/docs/00-portfolio/features/10-docs-governance-integration/reviewer-guidance.md
@@ -83,7 +83,7 @@ tags: [portfolio, features, documentation, reviewer]
 
 ### Additional internal references
 
-- [`/20-engineering/ux-design-system.md`](/docs/20-engineering/ux-design-system.md)
+- [`/20-engineering/ux-design-system.md`](/20-engineering/ux-design-system.md)
 
 ### External reference links
 

--- a/docs/00-portfolio/known-limitations.md
+++ b/docs/00-portfolio/known-limitations.md
@@ -63,6 +63,6 @@ Document known limitations and intentional omissions to keep expectations clear 
 
 ## References
 
-- Roadmap: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
-- Release notes: [/docs/00-portfolio/release-notes/index.md](/docs/00-portfolio/release-notes/index.md)
-- Portfolio index: [/docs/00-portfolio/index.md](/docs/00-portfolio/index.md)
+- Roadmap: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)
+- Release notes: [/docs/00-portfolio/release-notes/index.md](/00-portfolio/release-notes/index.md)
+- Portfolio index: [/docs/00-portfolio/index.md](/00-portfolio/index.md)

--- a/docs/00-portfolio/portfolio-archival-policy.md
+++ b/docs/00-portfolio/portfolio-archival-policy.md
@@ -66,6 +66,6 @@ Define how portfolio content is deprecated and archived without breaking reviewe
 
 ## References
 
-- Portfolio versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/docs/00-portfolio/portfolio-versioning-policy.md)
-- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/docs/00-portfolio/portfolio-change-intake.md)
-- Archival runbook: [/docs/50-operations/runbooks/rbk-portfolio-archival.md](/docs/50-operations/runbooks/rbk-portfolio-archival.md)
+- Portfolio versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/00-portfolio/portfolio-versioning-policy.md)
+- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/00-portfolio/portfolio-change-intake.md)
+- Archival runbook: [/docs/50-operations/runbooks/rbk-portfolio-archival.md](/50-operations/runbooks/rbk-portfolio-archival.md)

--- a/docs/00-portfolio/portfolio-change-intake.md
+++ b/docs/00-portfolio/portfolio-change-intake.md
@@ -66,6 +66,6 @@ Provide a repeatable intake process that enforces evidence requirements and prot
 
 ## References
 
-- Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/docs/00-portfolio/portfolio-eligibility-criteria.md)
-- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/docs/70-reference/evidence-audit-checklist.md)
-- Release notes: [/docs/00-portfolio/release-notes/index.md](/docs/00-portfolio/release-notes/index.md)
+- Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/00-portfolio/portfolio-eligibility-criteria.md)
+- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/70-reference/evidence-audit-checklist.md)
+- Release notes: [/docs/00-portfolio/release-notes/index.md](/00-portfolio/release-notes/index.md)

--- a/docs/00-portfolio/portfolio-eligibility-criteria.md
+++ b/docs/00-portfolio/portfolio-eligibility-criteria.md
@@ -72,6 +72,6 @@ Define clear rules for what belongs in the portfolio, what does not, and the min
 
 ## References
 
-- Reviewer guide: [/docs/00-portfolio/reviewer-guide.md](/docs/00-portfolio/reviewer-guide.md)
-- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/docs/70-reference/evidence-audit-checklist.md)
-- Roadmap: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
+- Reviewer guide: [/docs/00-portfolio/reviewer-guide.md](/00-portfolio/reviewer-guide.md)
+- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/70-reference/evidence-audit-checklist.md)
+- Roadmap: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)

--- a/docs/00-portfolio/portfolio-versioning-policy.md
+++ b/docs/00-portfolio/portfolio-versioning-policy.md
@@ -73,6 +73,6 @@ Use semantic versioning (SemVer): `vMAJOR.MINOR.PATCH`.
 
 ## References
 
-- Release notes: [/docs/00-portfolio/release-notes/index.md](/docs/00-portfolio/release-notes/index.md)
-- Roadmap: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
-- ADR-0017: [/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md](/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md)
+- Release notes: [/docs/00-portfolio/release-notes/index.md](/00-portfolio/release-notes/index.md)
+- Roadmap: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)
+- ADR-0017: [/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md](/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md)

--- a/docs/00-portfolio/release-notes/20260117-portfolio-app-phase-1-complete.md
+++ b/docs/00-portfolio/release-notes/20260117-portfolio-app-phase-1-complete.md
@@ -233,11 +233,11 @@ The Phase 1 release is valid when:
 
 ## Architecture & Governance References
 
-- [ADR-0007: Portfolio App Hosting on Vercel with Promotion Checks](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
-- [ADR-0008: Portfolio App CI Quality Gates](/docs/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md)
-- [Portfolio App Deployment Dossier](/docs/60-projects/portfolio-app/03-deployment.md)
-- [Vercel Setup Runbook](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md)
-- [GitHub Ruleset Configuration Guide](/docs/70-reference/portfolio-app-github-ruleset-config.md)
+- [ADR-0007: Portfolio App Hosting on Vercel with Promotion Checks](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
+- [ADR-0008: Portfolio App CI Quality Gates](/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md)
+- [Portfolio App Deployment Dossier](/60-projects/portfolio-app/03-deployment.md)
+- [Vercel Setup Runbook](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md)
+- [GitHub Ruleset Configuration Guide](/70-reference/portfolio-app-github-ruleset-config.md)
 
 ---
 

--- a/docs/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md
+++ b/docs/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md
@@ -426,33 +426,33 @@ Phase 2 establishes credibility through one exemplary "gold standard" project. T
 
 ### Project Documentation
 
-- [Portfolio App Dossier](/docs/60-projects/portfolio-app/index.md) — Comprehensive project overview
-- [Portfolio App Index](/docs/60-projects/portfolio-app/index.md) — Current phase status and deliverables
-- [Architecture Documentation](/docs/60-projects/portfolio-app/02-architecture.md) — Tech stack and patterns
-- [Security Documentation](/docs/60-projects/portfolio-app/04-security.md) — Public-safety rules and controls
+- [Portfolio App Dossier](/60-projects/portfolio-app/index.md) — Comprehensive project overview
+- [Portfolio App Index](/60-projects/portfolio-app/index.md) — Current phase status and deliverables
+- [Architecture Documentation](/60-projects/portfolio-app/02-architecture.md) — Tech stack and patterns
+- [Security Documentation](/60-projects/portfolio-app/04-security.md) — Public-safety rules and controls
 
 ### Security & Operations
 
-- [Threat Model: Portfolio App](/docs/40-security/threat-models/portfolio-app-threat-model.md) — STRIDE analysis
-- [STRIDE Compliance Report](/docs/40-security/threat-models/portfolio-app-stride-compliance-report.md) — Mitigation status
-- [Operational Runbooks Index](/docs/50-operations/runbooks/index.md) — All operational procedures
-- [Deploy Runbook](/docs/50-operations/runbooks/rbk-portfolio-deploy.md) — Production deployment
-- [CI Triage Runbook](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md) — Build failure diagnosis
-- [Rollback Runbook](/docs/50-operations/runbooks/rbk-portfolio-rollback.md) — Emergency rollback
-- [Secrets Incident Response](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md) — 5-phase incident procedure
+- [Threat Model: Portfolio App](/40-security/threat-models/portfolio-app-threat-model.md) — STRIDE analysis
+- [STRIDE Compliance Report](/40-security/threat-models/portfolio-app-stride-compliance-report.md) — Mitigation status
+- [Operational Runbooks Index](/50-operations/runbooks/index.md) — All operational procedures
+- [Deploy Runbook](/50-operations/runbooks/rbk-portfolio-deploy.md) — Production deployment
+- [CI Triage Runbook](/50-operations/runbooks/rbk-portfolio-ci-triage.md) — Build failure diagnosis
+- [Rollback Runbook](/50-operations/runbooks/rbk-portfolio-rollback.md) — Emergency rollback
+- [Secrets Incident Response](/50-operations/runbooks/rbk-portfolio-secrets-incident.md) — 5-phase incident procedure
 
 ### Architecture Decisions
 
-- [ADR Index](/docs/10-architecture/adr/index.md) — All architecture decisions
-- [ADR-0010: Portfolio App as Gold Standard Exemplar](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md) — Phase 2 strategy
-- [ADR-0009: React Compiler](/docs/10-architecture/adr/adr-0009-portfolio-app-react-compiler.md) — Automatic optimization
-- [ADR-0008: CI Quality Gates](/docs/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md) — CI pipeline design
-- [ADR-0007: Vercel Hosting with Promotion Checks](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) — Deployment strategy
+- [ADR Index](/10-architecture/adr/index.md) — All architecture decisions
+- [ADR-0010: Portfolio App as Gold Standard Exemplar](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md) — Phase 2 strategy
+- [ADR-0009: React Compiler](/10-architecture/adr/adr-0009-portfolio-app-react-compiler.md) — Automatic optimization
+- [ADR-0008: CI Quality Gates](/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md) — CI pipeline design
+- [ADR-0007: Vercel Hosting with Promotion Checks](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) — Deployment strategy
 
 ### Related Release Notes
 
-- [Portfolio App Baseline (2026-01-10)](/docs/00-portfolio/release-notes/20260110-portfolio-app-baseline.md) — Initial delivery
-- [Portfolio App Phase 1 Complete (2026-01-17)](/docs/00-portfolio/release-notes/20260117-portfolio-app-phase-1-complete.md) — Foundation complete
+- [Portfolio App Baseline (2026-01-10)](/00-portfolio/release-notes/20260110-portfolio-app-baseline.md) — Initial delivery
+- [Portfolio App Phase 1 Complete (2026-01-17)](/00-portfolio/release-notes/20260117-portfolio-app-phase-1-complete.md) — Foundation complete
 
 ---
 

--- a/docs/00-portfolio/release-notes/20260130-portfolio-app-phase-4-complete.md
+++ b/docs/00-portfolio/release-notes/20260130-portfolio-app-phase-4-complete.md
@@ -17,20 +17,20 @@ Phase 4 is complete. The portfolio now demonstrates enterprise-grade operational
 
 # Added
 
-- Observability & Health Checks guide: [/docs/30-devops-platform/observability-health-checks.md](/docs/30-devops-platform/observability-health-checks.md)
-- UX design system guide: [/docs/20-engineering/ux-design-system.md](/docs/20-engineering/ux-design-system.md)
-- SEO metadata reference: [/docs/70-reference/seo-metadata-guide.md](/docs/70-reference/seo-metadata-guide.md)
-- Theme system reference: [/docs/70-reference/theme-system-reference.md](/docs/70-reference/theme-system-reference.md)
+- Observability & Health Checks guide: [/docs/30-devops-platform/observability-health-checks.md](/30-devops-platform/observability-health-checks.md)
+- UX design system guide: [/docs/20-engineering/ux-design-system.md](/20-engineering/ux-design-system.md)
+- SEO metadata reference: [/docs/70-reference/seo-metadata-guide.md](/70-reference/seo-metadata-guide.md)
+- Theme system reference: [/docs/70-reference/theme-system-reference.md](/70-reference/theme-system-reference.md)
 - ADRs for dark mode, metadata strategy, and scroll animations:
-  - [/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md](/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md)
-  - [/docs/10-architecture/adr/adr-0015-metadata-strategy.md](/docs/10-architecture/adr/adr-0015-metadata-strategy.md)
-  - [/docs/10-architecture/adr/adr-0016-scroll-animations.md](/docs/10-architecture/adr/adr-0016-scroll-animations.md)
+  - [/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md](/10-architecture/adr/adr-0014-class-based-dark-mode.md)
+  - [/docs/10-architecture/adr/adr-0015-metadata-strategy.md](/10-architecture/adr/adr-0015-metadata-strategy.md)
+  - [/docs/10-architecture/adr/adr-0016-scroll-animations.md](/10-architecture/adr/adr-0016-scroll-animations.md)
 
 # Changed
 
 - Portfolio dossier updated for Phase 4 features and evidence links:
-  - [/docs/60-projects/portfolio-app/01-overview.md](/docs/60-projects/portfolio-app/01-overview.md)
-  - [/docs/60-projects/portfolio-app/02-architecture.md](/docs/60-projects/portfolio-app/02-architecture.md)
+  - [/docs/60-projects/portfolio-app/01-overview.md](/60-projects/portfolio-app/01-overview.md)
+  - [/docs/60-projects/portfolio-app/02-architecture.md](/60-projects/portfolio-app/02-architecture.md)
 - Operations and security references updated to new observability and security locations
 
 # Removed

--- a/docs/00-portfolio/release-notes/20260204-portfolio-phase-5-freeze.md
+++ b/docs/00-portfolio/release-notes/20260204-portfolio-phase-5-freeze.md
@@ -16,9 +16,9 @@ Phase 5 professionalization is in progress. This release note documents the revi
 
 # Added
 
-- Reviewer guide: [/docs/00-portfolio/reviewer-guide.md](/docs/00-portfolio/reviewer-guide.md)
-- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/docs/70-reference/evidence-audit-checklist.md)
-- Known limitations: [/docs/00-portfolio/known-limitations.md](/docs/00-portfolio/known-limitations.md)
+- Reviewer guide: [/docs/00-portfolio/reviewer-guide.md](/00-portfolio/reviewer-guide.md)
+- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/70-reference/evidence-audit-checklist.md)
+- Known limitations: [/docs/00-portfolio/known-limitations.md](/00-portfolio/known-limitations.md)
 
 # Changed
 

--- a/docs/00-portfolio/release-notes/20260204-portfolio-v1-0.md
+++ b/docs/00-portfolio/release-notes/20260204-portfolio-v1-0.md
@@ -16,9 +16,9 @@ Portfolio v1.0 is ready. Phase 5 professionalization is complete with reviewer-f
 
 # Added
 
-- Reviewer guide: [/docs/00-portfolio/reviewer-guide.md](/docs/00-portfolio/reviewer-guide.md)
-- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/docs/70-reference/evidence-audit-checklist.md)
-- Known limitations: [/docs/00-portfolio/known-limitations.md](/docs/00-portfolio/known-limitations.md)
+- Reviewer guide: [/docs/00-portfolio/reviewer-guide.md](/00-portfolio/reviewer-guide.md)
+- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/70-reference/evidence-audit-checklist.md)
+- Known limitations: [/docs/00-portfolio/known-limitations.md](/00-portfolio/known-limitations.md)
 
 # Changed
 

--- a/docs/00-portfolio/release-notes/20260205-portfolio-phase-6.md
+++ b/docs/00-portfolio/release-notes/20260205-portfolio-phase-6.md
@@ -16,12 +16,12 @@ Phase 6 establishes the long-term governance baseline for the portfolio. Inclusi
 
 # Added
 
-- Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/docs/00-portfolio/portfolio-eligibility-criteria.md)
-- Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/docs/00-portfolio/portfolio-versioning-policy.md)
-- Archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/docs/00-portfolio/portfolio-archival-policy.md)
-- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/docs/00-portfolio/portfolio-change-intake.md)
-- ADR-0017: [/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md](/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md)
-- Archival runbook: [/docs/50-operations/runbooks/rbk-portfolio-archival.md](/docs/50-operations/runbooks/rbk-portfolio-archival.md)
+- Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/00-portfolio/portfolio-eligibility-criteria.md)
+- Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/00-portfolio/portfolio-versioning-policy.md)
+- Archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/00-portfolio/portfolio-archival-policy.md)
+- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/00-portfolio/portfolio-change-intake.md)
+- ADR-0017: [/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md](/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md)
+- Archival runbook: [/docs/50-operations/runbooks/rbk-portfolio-archival.md](/50-operations/runbooks/rbk-portfolio-archival.md)
 
 # Changed
 

--- a/docs/00-portfolio/release-notes/20260205-portfolio-security-hardening.md
+++ b/docs/00-portfolio/release-notes/20260205-portfolio-security-hardening.md
@@ -17,16 +17,16 @@ Security hardening updates are now in place for both the Portfolio Docs App and 
 
 # Added
 
-- Docs hardening plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/docs/40-security/portfolio-docs-hardening-implementation-plan.md)
-- ADR-0019 (docs hardening baseline): [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
-- ADR-0018 (app hardening baseline): [/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md](/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
+- Docs hardening plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/40-security/portfolio-docs-hardening-implementation-plan.md)
+- ADR-0019 (docs hardening baseline): [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
+- ADR-0018 (app hardening baseline): [/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md](/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
 - Host-level headers configuration for docs: [vercel.json](https://github.com/bryce-seefieldt/portfolio-docs/blob/main/vercel.json)
 
 # Changed
 
-- Security policies updated with docs-specific CSP and MDX controls: [/docs/40-security/security-policies.md](/docs/40-security/security-policies.md)
-- Docs deployment runbook now includes header verification: [/docs/50-operations/runbooks/rbk-docs-deploy.md](/docs/50-operations/runbooks/rbk-docs-deploy.md)
-- Docs dossier security page references hardening plan and header checks: [/docs/60-projects/portfolio-docs-app/04-security.md](/docs/60-projects/portfolio-docs-app/04-security.md)
+- Security policies updated with docs-specific CSP and MDX controls: [/docs/40-security/security-policies.md](/40-security/security-policies.md)
+- Docs deployment runbook now includes header verification: [/docs/50-operations/runbooks/rbk-docs-deploy.md](/50-operations/runbooks/rbk-docs-deploy.md)
+- Docs dossier security page references hardening plan and header checks: [/docs/60-projects/portfolio-docs-app/04-security.md](/60-projects/portfolio-docs-app/04-security.md)
 - PR checklist includes MDX review and header verification prompts: [/.github/PULL_REQUEST_TEMPLATE.md](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/.github/PULL_REQUEST_TEMPLATE.md)
 
 # Governance and security baselines

--- a/docs/00-portfolio/reviewer-guide.md
+++ b/docs/00-portfolio/reviewer-guide.md
@@ -41,20 +41,20 @@ Provide a concise, reviewer-first path to validate the portfolio quickly while k
 
 3. **Dossier validation**
    - Read the Portfolio App dossier entry page:
-     - [/docs/60-projects/portfolio-app/index.md](/docs/60-projects/portfolio-app/index.md)
+     - [/docs/60-projects/portfolio-app/index.md](/60-projects/portfolio-app/index.md)
 
 4. **Security & operations**
-   - Threat model index: [/docs/40-security/threat-models/index.md](/docs/40-security/threat-models/index.md)
-   - Runbooks index: [/docs/50-operations/runbooks/index.md](/docs/50-operations/runbooks/index.md)
+   - Threat model index: [/docs/40-security/threat-models/index.md](/40-security/threat-models/index.md)
+   - Runbooks index: [/docs/50-operations/runbooks/index.md](/50-operations/runbooks/index.md)
 
 5. **Testing & CI evidence**
-   - Testing guide: [/docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md)
-   - CI overview: [/docs/30-devops-platform/ci-cd-pipeline-overview.md](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+   - Testing guide: [/docs/70-reference/testing-guide.md](/70-reference/testing-guide.md)
+   - CI overview: [/docs/30-devops-platform/ci-cd-pipeline-overview.md](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 6. **Governance policies**
-   - Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/docs/00-portfolio/portfolio-eligibility-criteria.md)
-   - Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/docs/00-portfolio/portfolio-versioning-policy.md)
-   - Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/docs/00-portfolio/portfolio-change-intake.md)
+   - Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/00-portfolio/portfolio-eligibility-criteria.md)
+   - Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/00-portfolio/portfolio-versioning-policy.md)
+   - Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/00-portfolio/portfolio-change-intake.md)
 
 ## Validation / Expected outcomes
 
@@ -69,9 +69,9 @@ Provide a concise, reviewer-first path to validate the portfolio quickly while k
 
 ## References
 
-- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/docs/70-reference/evidence-audit-checklist.md)
-- Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/docs/00-portfolio/portfolio-eligibility-criteria.md)
-- Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/docs/00-portfolio/portfolio-versioning-policy.md)
-- Archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/docs/00-portfolio/portfolio-archival-policy.md)
-- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/docs/00-portfolio/portfolio-change-intake.md)
-- Roadmap: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
+- Evidence audit checklist: [/docs/70-reference/evidence-audit-checklist.md](/70-reference/evidence-audit-checklist.md)
+- Eligibility criteria: [/docs/00-portfolio/portfolio-eligibility-criteria.md](/00-portfolio/portfolio-eligibility-criteria.md)
+- Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/00-portfolio/portfolio-versioning-policy.md)
+- Archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/00-portfolio/portfolio-archival-policy.md)
+- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/00-portfolio/portfolio-change-intake.md)
+- Roadmap: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)

--- a/docs/00-portfolio/roadmap/index.md
+++ b/docs/00-portfolio/roadmap/index.md
@@ -147,7 +147,7 @@ Ensure the Documentation App is a credible enterprise evidence engine with stron
 
 ## Phase 1 — Portfolio App foundation (production-quality skeleton)
 
-**Status:** ✅ Complete (2026-01-17) — see [Phase 1 Implementation Guide](/docs/00-portfolio/roadmap/phase-1-implementation-guide.md)
+**Status:** ✅ Complete (2026-01-17) — see [Phase 1 Implementation Guide](/00-portfolio/roadmap/phase-1-implementation-guide.md)
 
 ### Objective
 
@@ -185,7 +185,7 @@ Stand up the Portfolio App with enterprise-grade SDLC controls and a minimal, po
 
 ## Phase 2 — “Gold standard” project and credibility baseline
 
-**Status:** ✅ Complete (2026-01-21) — see [Phase 2 Implementation Guide](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
+**Status:** ✅ Complete (2026-01-21) — see [Phase 2 Implementation Guide](/00-portfolio/roadmap/phase-2-implementation-guide.md)
 
 ### Objective
 
@@ -271,7 +271,7 @@ Beyond baseline Phase 1, Phase 2 includes optional hardening controls that stren
 - ✅ STRIDE compliance report generated
 - ✅ All controls integrated into PR workflow
 
-## See [Phase 2 Implementation Guide — STEP 4a/4b](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md#step-4a-phase-2-security-enhancements-hardening-controls--23-hours) for detailed procedures.
+## See [Phase 2 Implementation Guide — STEP 4a/4b](/00-portfolio/roadmap/phase-2-implementation-guide.md#step-4a-phase-2-security-enhancements-hardening-controls--23-hours) for detailed procedures.
 
 ## Phase 3 — Repeatable project publishing pipeline (scale without chaos)
 
@@ -310,7 +310,7 @@ Make adding projects predictable, low-friction, and consistent with governance.
 
 ## Phase 4 — Reliability, performance, and security hardening (enterprise maturity)
 
-**Status:** ✅ Complete (2026-01-30) — see [Phase 4 Implementation Guide](/docs/00-portfolio/roadmap/phase-4-implementation-guide.md) and [Release Note: Phase 4 Completion](/docs/00-portfolio/release-notes/20260130-portfolio-app-phase-4-complete.md)
+**Status:** ✅ Complete (2026-01-30) — see [Phase 4 Implementation Guide](/00-portfolio/roadmap/phase-4-implementation-guide.md) and [Release Note: Phase 4 Completion](/00-portfolio/release-notes/20260130-portfolio-app-phase-4-complete.md)
 
 ### Deliverables (Portfolio App)
 

--- a/docs/00-portfolio/roadmap/issues/index.md
+++ b/docs/00-portfolio/roadmap/issues/index.md
@@ -41,6 +41,6 @@ Use this index to find the canonical task descriptions, acceptance criteria, and
 
 ## See Also
 
-- Roadmap hub: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
-- Phase 3 Implementation Guide: [/docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)
-- Phase 4 Implementation Guide: [/docs/00-portfolio/roadmap/phase-4-implementation-guide.md](/docs/00-portfolio/roadmap/phase-4-implementation-guide.md)
+- Roadmap hub: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)
+- Phase 3 Implementation Guide: [/docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md)
+- Phase 4 Implementation Guide: [/docs/00-portfolio/roadmap/phase-4-implementation-guide.md](/00-portfolio/roadmap/phase-4-implementation-guide.md)

--- a/docs/00-portfolio/roadmap/phase-1-implementation-guide.md
+++ b/docs/00-portfolio/roadmap/phase-1-implementation-guide.md
@@ -1036,8 +1036,8 @@ With Phase 1 establishing production infrastructure and governance, Phase 2 will
 
 Quick troubleshooting reference for Phase 1 implementation:
 
-| Problem                                    | Quick Fix                                                                                           | Detailed Guide                                                                                                            |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Problem                                    | Quick Fix                                                                                           | Detailed Guide                                                                                                       |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | **Vercel waits for checks indefinitely**   | Verify `ci.yml` runs on `push: [main]` and check names match exactly (`ci / quality`, `ci / build`) | [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
 | **Preview deployment fails**               | Verify Node version (20.x) and pnpm version (9+) match in Vercel settings                           | [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
 | **Evidence links broken in preview**       | Verify `NEXT_PUBLIC_DOCS_BASE_URL` is set for Preview scope in Vercel                               | [Portfolio App Dossier - Deployment](/60-projects/portfolio-app/03-deployment.md)                                    |

--- a/docs/00-portfolio/roadmap/phase-1-implementation-guide.md
+++ b/docs/00-portfolio/roadmap/phase-1-implementation-guide.md
@@ -946,10 +946,10 @@ A reviewer can validate Phase 1 completion through:
    - Check environment variables are applied (links to docs resolve)
 
 3. **Documentation Evidence:**
-   - Review [Portfolio App Dossier](/docs/60-projects/portfolio-app/index.md)
-   - Review [ADR-0005](/docs/10-architecture/adr/adr-0005-portfolio-app-stack-nextjs-ts.md), [ADR-0006](/docs/10-architecture/adr/adr-0006-separate-portfolio-app-from-evidence-engine-docs.md), [ADR-0007](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
-   - Review [Threat Model](/docs/40-security/threat-models/portfolio-app-threat-model.md)
-   - Review [Operational Runbooks](/docs/50-operations/runbooks/index.md)
+   - Review [Portfolio App Dossier](/60-projects/portfolio-app/index.md)
+   - Review [ADR-0005](/10-architecture/adr/adr-0005-portfolio-app-stack-nextjs-ts.md), [ADR-0006](/10-architecture/adr/adr-0006-separate-portfolio-app-from-evidence-engine-docs.md), [ADR-0007](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
+   - Review [Threat Model](/40-security/threat-models/portfolio-app-threat-model.md)
+   - Review [Operational Runbooks](/50-operations/runbooks/index.md)
 
 4. **Governance Validation:**
    - Create test PR in portfolio-app
@@ -1026,9 +1026,9 @@ With Phase 1 establishing production infrastructure and governance, Phase 2 will
 
 ### Planning Documents
 
-- **Phase 2 Implementation Guide:** [/docs/00-portfolio/roadmap/phase-2-implementation-guide.md](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
-- **Roadmap (Phase 2 section):** [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md#phase-2--gold-standard-project-and-credibility-baseline)
-- **ADR-0010:** [Portfolio App as Gold Standard Exemplar](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
+- **Phase 2 Implementation Guide:** [/docs/00-portfolio/roadmap/phase-2-implementation-guide.md](/00-portfolio/roadmap/phase-2-implementation-guide.md)
+- **Roadmap (Phase 2 section):** [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md#phase-2--gold-standard-project-and-credibility-baseline)
+- **ADR-0010:** [Portfolio App as Gold Standard Exemplar](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
 
 ---
 
@@ -1038,23 +1038,23 @@ Quick troubleshooting reference for Phase 1 implementation:
 
 | Problem                                    | Quick Fix                                                                                           | Detailed Guide                                                                                                            |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **Vercel waits for checks indefinitely**   | Verify `ci.yml` runs on `push: [main]` and check names match exactly (`ci / quality`, `ci / build`) | [rbk-vercel-setup-and-promotion-validation.md](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
-| **Preview deployment fails**               | Verify Node version (20.x) and pnpm version (9+) match in Vercel settings                           | [rbk-vercel-setup-and-promotion-validation.md](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
-| **Evidence links broken in preview**       | Verify `NEXT_PUBLIC_DOCS_BASE_URL` is set for Preview scope in Vercel                               | [Portfolio App Dossier - Deployment](/docs/60-projects/portfolio-app/03-deployment.md)                                    |
-| **Merge button disabled when checks pass** | Verify GitHub Ruleset is **Active** (not Evaluate/Disabled)                                         | [portfolio-app-github-ruleset-config.md](/docs/70-reference/portfolio-app-github-ruleset-config.md)                       |
-| **CI checks don't appear in PR**           | Wait 3–5 minutes; verify `.github/workflows/ci.yml` exists and is valid; check Actions tab          | [rbk-portfolio-ci-triage.md](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)                                     |
-| **Environment variables not applied**      | Trigger manual redeploy in Vercel after saving environment variables                                | [rbk-vercel-setup-and-promotion-validation.md](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
-| **Production promotion doesn't trigger**   | Verify Deployment Checks are scoped to Production only; check CI passed before merge                | [ADR-0007](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)                      |
+| **Vercel waits for checks indefinitely**   | Verify `ci.yml` runs on `push: [main]` and check names match exactly (`ci / quality`, `ci / build`) | [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
+| **Preview deployment fails**               | Verify Node version (20.x) and pnpm version (9+) match in Vercel settings                           | [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
+| **Evidence links broken in preview**       | Verify `NEXT_PUBLIC_DOCS_BASE_URL` is set for Preview scope in Vercel                               | [Portfolio App Dossier - Deployment](/60-projects/portfolio-app/03-deployment.md)                                    |
+| **Merge button disabled when checks pass** | Verify GitHub Ruleset is **Active** (not Evaluate/Disabled)                                         | [portfolio-app-github-ruleset-config.md](/70-reference/portfolio-app-github-ruleset-config.md)                       |
+| **CI checks don't appear in PR**           | Wait 3–5 minutes; verify `.github/workflows/ci.yml` exists and is valid; check Actions tab          | [rbk-portfolio-ci-triage.md](/50-operations/runbooks/rbk-portfolio-ci-triage.md)                                     |
+| **Environment variables not applied**      | Trigger manual redeploy in Vercel after saving environment variables                                | [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) |
+| **Production promotion doesn't trigger**   | Verify Deployment Checks are scoped to Production only; check CI passed before merge                | [ADR-0007](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)                      |
 
 ---
 
 ## Related Documentation
 
-- **Roadmap:** [Portfolio Web Application Roadmap](/docs/00-portfolio/roadmap/index.md)
-- **Phase 2 Implementation Guide:** [Phase 2: Gold Standard Project](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
-- **Portfolio App Dossier:** [Project Portfolio App](/docs/60-projects/portfolio-app/index.md)
-- **ADR Index:** [Architecture Decision Records](/docs/10-architecture/adr/index.md)
-- **Runbooks Index:** [Operations Runbooks](/docs/50-operations/runbooks/index.md)
+- **Roadmap:** [Portfolio Web Application Roadmap](/00-portfolio/roadmap/index.md)
+- **Phase 2 Implementation Guide:** [Phase 2: Gold Standard Project](/00-portfolio/roadmap/phase-2-implementation-guide.md)
+- **Portfolio App Dossier:** [Project Portfolio App](/60-projects/portfolio-app/index.md)
+- **ADR Index:** [Architecture Decision Records](/10-architecture/adr/index.md)
+- **Runbooks Index:** [Operations Runbooks](/50-operations/runbooks/index.md)
 
 ---
 

--- a/docs/00-portfolio/roadmap/phase-2-implementation-guide.md
+++ b/docs/00-portfolio/roadmap/phase-2-implementation-guide.md
@@ -85,7 +85,7 @@ Start with **portfolio-app** as the gold standard. Rationale:
 
 **Action items:**
 
-1. ✅ **Decision documented in ADR-0010** — see [ADR-0010: Portfolio App as Gold Standard Exemplar](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
+1. ✅ **Decision documented in ADR-0010** — see [ADR-0010: Portfolio App as Gold Standard Exemplar](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
    - Portfolio App selected as the exemplary project
    - Rationale, consequences, and implementation approach documented
    - Alternatives considered and rejected
@@ -803,8 +803,8 @@ git config core.hooksPath .git/hooks  # One-time setup
 
 **Threat Model Alignment:**
 
-- Ref: [Threat Model — Information Disclosure](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-1-attacker-exfiltrates-secrets-from-environment-or-repository)
-- Ref: [Threat Model — Tampering](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-modifies-ci-workflows-or-build-scripts-to-inject-malicious-code)
+- Ref: [Threat Model — Information Disclosure](/40-security/threat-models/portfolio-app-threat-model.md#threat-1-attacker-exfiltrates-secrets-from-environment-or-repository)
+- Ref: [Threat Model — Tampering](/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-modifies-ci-workflows-or-build-scripts-to-inject-malicious-code)
 
 **Success check:**
 
@@ -849,7 +849,7 @@ git config core.hooksPath .git/hooks  # One-time setup
 
 **Threat Model Alignment:**
 
-- Ref: [Threat Model — Incident Response](/docs/40-security/threat-models/portfolio-app-threat-model.md#incident-response)
+- Ref: [Threat Model — Incident Response](/40-security/threat-models/portfolio-app-threat-model.md#incident-response)
 - Covers: Information Disclosure (T1) response
 - Covers: Suspected malicious deployment response (T2)
 
@@ -898,13 +898,13 @@ This section summarizes all Phase 2 security and operational hardening applied t
 
 ### Operational Hardening
 
-- ✅ **Secrets incident response runbook** created: [rbk-portfolio-secrets-incident.md](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)
+- ✅ **Secrets incident response runbook** created: [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)
   - 5-phase response procedure: Detection → Containment → Eradication → Recovery → Postmortem
   - Aligned with STRIDE threat model mitigations
 - ✅ **Existing runbooks verified** for operational readiness:
-  - [rbk-portfolio-deploy.md](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
-  - [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
-  - [rbk-portfolio-ci-triage.md](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+  - [rbk-portfolio-deploy.md](/50-operations/runbooks/rbk-portfolio-deploy.md)
+  - [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md)
+  - [rbk-portfolio-ci-triage.md](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ### Evidence Artifacts
 
@@ -912,8 +912,8 @@ This section summarizes all Phase 2 security and operational hardening applied t
 - **Pre-commit Config:** [.pre-commit-config.yaml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.pre-commit-config.yaml)
 - **Package Scripts:** [package.json](https://github.com/bryce-seefieldt/portfolio-app/blob/main/package.json)
 - **Smoke Tests:** [tests/e2e/smoke.spec.ts](https://github.com/bryce-seefieldt/portfolio-app/blob/main/tests/e2e/smoke.spec.ts)
-- **Threat Model:** [Portfolio App STRIDE](/docs/40-security/threat-models/portfolio-app-threat-model.md)
-- **All Runbooks:** [Operations Runbooks Index](/docs/50-operations/runbooks/index.md)
+- **Threat Model:** [Portfolio App STRIDE](/40-security/threat-models/portfolio-app-threat-model.md)
+- **All Runbooks:** [Operations Runbooks Index](/50-operations/runbooks/index.md)
 
 ---
 
@@ -988,11 +988,11 @@ git push origin feat/my-feature
 
 ## Rollback
 
-If an issue is discovered post-deployment, see [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md).
+If an issue is discovered post-deployment, see [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md).
 
 ## Troubleshooting
 
-- Checks fail: See [rbk-portfolio-ci-triage.md](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- Checks fail: See [rbk-portfolio-ci-triage.md](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 - Preview doesn't update: Refresh Vercel dashboard or wait 2 minutes
 
 ````
@@ -1528,7 +1528,7 @@ export default function CVPage() {
 
 **Completion notes:**
 
-- Release note published: [20260120-portfolio-app-phase-2-gold-standard.md](/docs/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
+- Release note published: [20260120-portfolio-app-phase-2-gold-standard.md](/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
 
 release-notes/20260120-portfolio-app-phase-2-gold-standard.md(/docs/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
 
@@ -1657,8 +1657,8 @@ The Phase 2 release is valid when:
 
 ## Architecture & Governance References
 
-- [Portfolio App Dossier](/docs/60-projects/portfolio-app/index.md) (location TBD during implementation)
-- [Threat Model: Portfolio App](/docs/40-security/threat-models/) (location TBD during implementation)
+- [Portfolio App Dossier](/60-projects/portfolio-app/index.md) (location TBD during implementation)
+- [Threat Model: Portfolio App](/40-security/threat-models/) (location TBD during implementation)
 - Operational runbooks (created during Phase 2):
   - Deploy runbook
   - CI triage runbook
@@ -1864,11 +1864,11 @@ A reviewer can validate Phase 2 completion through:
    - Click evidence links to docs; verify they resolve correctly
 
 3. **Documentation Evidence:**
-   - Review [Portfolio App Dossier](/docs/60-projects/portfolio-app/index.md)
-   - Review [Threat Model](/docs/40-security/threat-models/portfolio-app-threat-model.md)
-   - Review [ADR-0010](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
-   - Review [Operational Runbooks](/docs/50-operations/runbooks/index.md)
-   - Review [Release Notes](/docs/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
+   - Review [Portfolio App Dossier](/60-projects/portfolio-app/index.md)
+   - Review [Threat Model](/40-security/threat-models/portfolio-app-threat-model.md)
+   - Review [ADR-0010](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
+   - Review [Operational Runbooks](/50-operations/runbooks/index.md)
+   - Review [Release Notes](/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
 
 4. **Automated Tests:**
    - Clone portfolio-app repo
@@ -1898,11 +1898,11 @@ A reviewer can validate Phase 2 completion through:
 
 **Evidence:**
 
-- [STRIDE compliance report](/docs/40-security/threat-models/portfolio-app-stride-compliance-report.md)
-- [Threat model](/docs/40-security/threat-models/portfolio-app-threat-model.md)
+- [STRIDE compliance report](/40-security/threat-models/portfolio-app-stride-compliance-report.md)
+- [Threat model](/40-security/threat-models/portfolio-app-threat-model.md)
 - [CI workflow](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml) (quality, secrets-scan, build, tests)
 - [Pre-commit config](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.pre-commit-config.yaml) (TruffleHog)
-- [Runbooks](/docs/50-operations/runbooks/index.md) (deploy, rollback, CI triage, secrets incident)
+- [Runbooks](/50-operations/runbooks/index.md) (deploy, rollback, CI triage, secrets incident)
 
 ---
 
@@ -2005,21 +2005,21 @@ With Phase 2 establishing credibility through one exemplary project, Phase 3 wil
 
 ### Planning Documents
 
-- **Phase 3 Implementation Guide:** [/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md))
-- **Roadmap (Phase 3 section):** [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md#phase-3--repeatable-project-publishing-pipeline-scale-without-chaos)
+- **Phase 3 Implementation Guide:** [/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)](/00-portfolio/roadmap/phase-3-implementation-guide.md))
+- **Roadmap (Phase 3 section):** [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md#phase-3--repeatable-project-publishing-pipeline-scale-without-chaos)
 
 ---
 
 ## Related Documentation
 
-- **Roadmap:** [Portfolio Web Application Roadmap](/docs/00-portfolio/roadmap/index.md)
-- **Phase 1 Implementation Guide:** [Phase 1: Portfolio App Foundation](/docs/00-portfolio/roadmap/phase-1-implementation-guide.md)
-- **ADR-0010:** [Portfolio App as Gold Standard Exemplar](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
-- **Phase 2 Release Notes:** [20260119 Portfolio App Phase 2 Complete](/docs/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
-- **Portfolio App Dossier:** [Project Portfolio App](/docs/60-projects/portfolio-app/index.md)
-- **Threat Model:** [Portfolio App Threat Model](/docs/40-security/threat-models/portfolio-app-threat-model.md)
-- **Runbooks Index:** [Operations Runbooks](/docs/50-operations/runbooks/index.md)
-- **ADR Index:** [Architecture Decision Records](/docs/10-architecture/adr/index.md)
+- **Roadmap:** [Portfolio Web Application Roadmap](/00-portfolio/roadmap/index.md)
+- **Phase 1 Implementation Guide:** [Phase 1: Portfolio App Foundation](/00-portfolio/roadmap/phase-1-implementation-guide.md)
+- **ADR-0010:** [Portfolio App as Gold Standard Exemplar](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
+- **Phase 2 Release Notes:** [20260119 Portfolio App Phase 2 Complete](/00-portfolio/release-notes/20260120-portfolio-app-phase-2-gold-standard.md)
+- **Portfolio App Dossier:** [Project Portfolio App](/60-projects/portfolio-app/index.md)
+- **Threat Model:** [Portfolio App Threat Model](/40-security/threat-models/portfolio-app-threat-model.md)
+- **Runbooks Index:** [Operations Runbooks](/50-operations/runbooks/index.md)
+- **ADR Index:** [Architecture Decision Records](/10-architecture/adr/index.md)
 
 ---
 

--- a/docs/00-portfolio/roadmap/phase-3-implementation-guide.md
+++ b/docs/00-portfolio/roadmap/phase-3-implementation-guide.md
@@ -312,9 +312,9 @@ Before starting Phase 3, ensure:
 
 ## Reference Documentation
 
-- [Roadmap — Phase 3](/docs/00-portfolio/roadmap/index.md)
+- [Roadmap — Phase 3](/00-portfolio/roadmap/index.md)
 - [Session Context — Phase 3 Ready](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/.copilot/session-context.md)
-- [ADR Index](/docs/10-architecture/adr/index.md)
+- [ADR Index](/10-architecture/adr/index.md)
 - [Portfolio App Dossier](docs/60-projects/portfolio-app/index.md)
 - [Reference Section](docs/70-reference/index.md)
 

--- a/docs/00-portfolio/roadmap/phase-4-implementation-guide.md
+++ b/docs/00-portfolio/roadmap/phase-4-implementation-guide.md
@@ -1131,13 +1131,13 @@ pnpm start                      # Local dev server
 
 ## Reference Documentation
 
-- [Roadmap — Portfolio Program](/docs/00-portfolio/roadmap/index.md)
-- [Phase 3 Implementation Guide (predecessor)](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)
-- [Architecture Decision Records (ADRs)](/docs/10-architecture/adr/index.md)
+- [Roadmap — Portfolio Program](/00-portfolio/roadmap/index.md)
+- [Phase 3 Implementation Guide (predecessor)](/00-portfolio/roadmap/phase-3-implementation-guide.md)
+- [Architecture Decision Records (ADRs)](/10-architecture/adr/index.md)
 - [Project Dossier Template](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/docs/_meta/templates/template-project-dossier/)
 - [Runbook Template](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/docs/_meta/templates/template-runbook.md)
 - [Threat Model Template](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/docs/_meta/templates/template-threat-model.md)
-- [Performance Guide (TBD)](/docs/70-reference/index.md)
+- [Performance Guide (TBD)](/70-reference/index.md)
 
 ---
 

--- a/docs/00-portfolio/roadmap/phase-6-implementation-guide.md
+++ b/docs/00-portfolio/roadmap/phase-6-implementation-guide.md
@@ -105,8 +105,8 @@ Specify the minimum evidence requirements for any new project entry.
 
 **Related documentation:**
 
-- See: [Reviewer Guide](/docs/00-portfolio/reviewer-guide.md)
-- Reference: [Evidence Audit Checklist](/docs/70-reference/evidence-audit-checklist.md)
+- See: [Reviewer Guide](/00-portfolio/reviewer-guide.md)
+- Reference: [Evidence Audit Checklist](/70-reference/evidence-audit-checklist.md)
 
 ---
 
@@ -160,8 +160,8 @@ Create guidance for retiring projects or documents while preserving evidence int
 
 **Related documentation:**
 
-- See: [Roadmap](/docs/00-portfolio/roadmap/index.md)
-- Reference: [ADR Index](/docs/10-architecture/adr/index.md)
+- See: [Roadmap](/00-portfolio/roadmap/index.md)
+- Reference: [ADR Index](/10-architecture/adr/index.md)
 
 ---
 
@@ -204,8 +204,8 @@ Add a release note entry documenting the Phase 6 governance update.
 
 **Related documentation:**
 
-- See: [Release Notes](/docs/00-portfolio/release-notes/index.md)
-- Reference: [Runbooks](/docs/50-operations/runbooks/index.md)
+- See: [Release Notes](/00-portfolio/release-notes/index.md)
+- Reference: [Runbooks](/50-operations/runbooks/index.md)
 
 ---
 
@@ -385,11 +385,11 @@ pnpm start
 
 ## Reference Documentation
 
-- [Roadmap - Phase 6](/docs/00-portfolio/roadmap/index.md)
-- [Reviewer Guide](/docs/00-portfolio/reviewer-guide.md)
-- [Evidence Audit Checklist](/docs/70-reference/evidence-audit-checklist.md)
-- [ADR Index](/docs/10-architecture/adr/index.md)
-- [Runbooks Index](/docs/50-operations/runbooks/index.md)
+- [Roadmap - Phase 6](/00-portfolio/roadmap/index.md)
+- [Reviewer Guide](/00-portfolio/reviewer-guide.md)
+- [Evidence Audit Checklist](/70-reference/evidence-audit-checklist.md)
+- [ADR Index](/10-architecture/adr/index.md)
+- [Runbooks Index](/50-operations/runbooks/index.md)
 
 ---
 

--- a/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md
+++ b/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md
@@ -11,7 +11,7 @@ tags:
 
 ## Context
 
-Phase 2 of the Portfolio Program (see [roadmap.md](/docs/00-portfolio/roadmap/index.md#phase-2--gold-standard-project-and-credibility-baseline) requires selecting one exemplary project to demonstrate senior-level engineering discipline. This project will serve as the template and quality bar for all future portfolio entries.
+Phase 2 of the Portfolio Program (see [roadmap.md](/00-portfolio/roadmap/index.md#phase-2--gold-standard-project-and-credibility-baseline) requires selecting one exemplary project to demonstrate senior-level engineering discipline. This project will serve as the template and quality bar for all future portfolio entries.
 
 Candidate projects were evaluated:
 
@@ -183,7 +183,7 @@ A senior engineer reviewing **portfolio-app** should conclude:
 
 ## Implementation
 
-**Location:** [Phase 2 Implementation Guide](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
+**Location:** [Phase 2 Implementation Guide](/00-portfolio/roadmap/phase-2-implementation-guide.md)
 
 **Phase 2 deliverables for portfolio-app:**
 
@@ -218,8 +218,8 @@ After Phase 2 completes, verify:
 
 ## Related documents
 
-- [Phase 2 Implementation Guide](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md) — step-by-step procedures
-- [Phase 1 Release Notes](/docs/00-portfolio/release-notes/20260117-portfolio-app-phase-1-complete.md) — Phase 1 completion status
-- [Portfolio Roadmap](/docs/00-portfolio/roadmap/index.md) — program-level planning
-- [ADR-0007: Vercel + Promotion Checks](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) — deployment decisions
-- [ADR-0008: CI Quality Gates](/docs/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md) — CI governance decisions
+- [Phase 2 Implementation Guide](/00-portfolio/roadmap/phase-2-implementation-guide.md) — step-by-step procedures
+- [Phase 1 Release Notes](/00-portfolio/release-notes/20260117-portfolio-app-phase-1-complete.md) — Phase 1 completion status
+- [Portfolio Roadmap](/00-portfolio/roadmap/index.md) — program-level planning
+- [ADR-0007: Vercel + Promotion Checks](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) — deployment decisions
+- [ADR-0008: CI Quality Gates](/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md) — CI governance decisions

--- a/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md
+++ b/docs/10-architecture/adr/adr-0017-portfolio-versioning-and-lifecycle.md
@@ -96,6 +96,6 @@ Key points:
 
 ## References
 
-- Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/docs/00-portfolio/portfolio-versioning-policy.md)
-- Archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/docs/00-portfolio/portfolio-archival-policy.md)
-- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/docs/00-portfolio/portfolio-change-intake.md)
+- Versioning policy: [/docs/00-portfolio/portfolio-versioning-policy.md](/00-portfolio/portfolio-versioning-policy.md)
+- Archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/00-portfolio/portfolio-archival-policy.md)
+- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/00-portfolio/portfolio-change-intake.md)

--- a/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md
+++ b/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md
@@ -98,7 +98,7 @@ Adopt a React2Shell hardening baseline that combines rapid patching with defense
 
 ## References
 
-- React2Shell hardening guide: [/docs/40-security/react2shell-hardening-implementation-guide.md](/docs/40-security/react2shell-hardening-implementation-guide.md)
-- Security policies: [/docs/40-security/security-policies.md](/docs/40-security/security-policies.md)
-- Risk register: [/docs/40-security/risk-register.md](/docs/40-security/risk-register.md)
-- Portfolio App security controls: [/docs/40-security/portfolio-app-security-controls.md](/docs/40-security/portfolio-app-security-controls.md)
+- React2Shell hardening guide: [/docs/40-security/react2shell-hardening-implementation-guide.md](/40-security/react2shell-hardening-implementation-guide.md)
+- Security policies: [/docs/40-security/security-policies.md](/40-security/security-policies.md)
+- Risk register: [/docs/40-security/risk-register.md](/40-security/risk-register.md)
+- Portfolio App security controls: [/docs/40-security/portfolio-app-security-controls.md](/40-security/portfolio-app-security-controls.md)

--- a/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md
+++ b/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md
@@ -67,6 +67,6 @@ Adopt a docs-specific hardening baseline with the following controls:
 
 ## References
 
-- Docs hardening implementation plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/docs/40-security/portfolio-docs-hardening-implementation-plan.md)
-- Security policies: [/docs/40-security/security-policies.md](/docs/40-security/security-policies.md)
-- React2Shell baseline ADR: [/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md](/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
+- Docs hardening implementation plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/40-security/portfolio-docs-hardening-implementation-plan.md)
+- Security policies: [/docs/40-security/security-policies.md](/40-security/security-policies.md)
+- React2Shell baseline ADR: [/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md](/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)

--- a/docs/10-architecture/adr/index.md
+++ b/docs/10-architecture/adr/index.md
@@ -130,6 +130,6 @@ This ADR system is successful when:
 
 ## Recent ADRs
 
-- [ADR-0020: Portfolio App UI and Route Testing Strategy](/docs/10-architecture/adr/adr-0020-portfolio-app-ui-testing-strategy.md)
-- [ADR-0018: React2Shell Hardening Baseline](/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
-- [ADR-0019: Portfolio Docs Hardening Baseline](/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
+- [ADR-0020: Portfolio App UI and Route Testing Strategy](/10-architecture/adr/adr-0020-portfolio-app-ui-testing-strategy.md)
+- [ADR-0018: React2Shell Hardening Baseline](/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
+- [ADR-0019: Portfolio Docs Hardening Baseline](/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)

--- a/docs/30-devops-platform/ci-cd-pipeline-overview.md
+++ b/docs/30-devops-platform/ci-cd-pipeline-overview.md
@@ -400,7 +400,7 @@ First-responder workflow:
 3. reproduce with repo verification command (`pnpm verify`)
 4. apply minimal fix and push back to the PR branch
 
-Use [Dependabot PR CI Remediation](/docs/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md) for full command-level procedure.
+Use [Dependabot PR CI Remediation](/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md) for full command-level procedure.
 
 ### Known failure patterns (dependency upgrades)
 
@@ -540,11 +540,11 @@ pnpm registry:list  # List all projects
 
 ## Related Documentation
 
-- **Testing Guide**: [docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md)
-- **Portfolio App Testing**: [docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md)
-- **Portfolio App Architecture**: [docs/60-projects/portfolio-app/02-architecture.md](/docs/60-projects/portfolio-app/02-architecture.md#testing-architecture-stage-33)
-- **Security ADRs**: [docs/10-architecture/adr/](/docs/10-architecture/adr/index.md) (CI security decisions)
-- **CI Triage Runbook**: [docs/50-operations/runbooks/rbk-portfolio-ci-triage.md](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- **Testing Guide**: [docs/70-reference/testing-guide.md](/70-reference/testing-guide.md)
+- **Portfolio App Testing**: [docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md)
+- **Portfolio App Architecture**: [docs/60-projects/portfolio-app/02-architecture.md](/60-projects/portfolio-app/02-architecture.md#testing-architecture-stage-33)
+- **Security ADRs**: [docs/10-architecture/adr/](/10-architecture/adr/index.md) (CI security decisions)
+- **CI Triage Runbook**: [docs/50-operations/runbooks/rbk-portfolio-ci-triage.md](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ## Maintenance & Evolution
 

--- a/docs/40-security/index.md
+++ b/docs/40-security/index.md
@@ -93,30 +93,30 @@ Security posture changes must be reflected in:
 
 Use these documents to plan and govern React2Shell-class hardening work:
 
-- Implementation guide: [/docs/40-security/react2shell-hardening-implementation-guide.md](/docs/40-security/react2shell-hardening-implementation-guide.md)
-- ADR-0018: [/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md](/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
+- Implementation guide: [/docs/40-security/react2shell-hardening-implementation-guide.md](/40-security/react2shell-hardening-implementation-guide.md)
+- ADR-0018: [/docs/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md](/10-architecture/adr/adr-0018-react2shell-hardening-baseline.md)
 
 ## Portfolio Docs Hardening Program
 
-- Implementation plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/docs/40-security/portfolio-docs-hardening-implementation-plan.md)
-- ADR-0019: [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
+- Implementation plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/40-security/portfolio-docs-hardening-implementation-plan.md)
+- ADR-0019: [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
 
 ## Security Posture Deepening
 
 **New Documentation:**
 
-- **[Threat Model v2](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)** — Extended threat model covering deployment surface and runtime misconfiguration risks with STRIDE analysis, residual risks, and mitigation summary
-- **[Risk Register](/docs/40-security/risk-register.md)** — Inventory of known security risks with severity, mitigations, and acceptance status; quarterly review schedule
-- **[Security Policies & Governance](/docs/40-security/security-policies.md)** — Formal policies for dependency audit, secrets management, security headers, and incident response
+- **[Threat Model v2](/40-security/threat-models/portfolio-app-threat-model-v2.md)** — Extended threat model covering deployment surface and runtime misconfiguration risks with STRIDE analysis, residual risks, and mitigation summary
+- **[Risk Register](/40-security/risk-register.md)** — Inventory of known security risks with severity, mitigations, and acceptance status; quarterly review schedule
+- **[Security Policies & Governance](/40-security/security-policies.md)** — Formal policies for dependency audit, secrets management, security headers, and incident response
 
 **Operational & Implementation References:**
 
-- **[Security Hardening Implementation](/docs/60-projects/portfolio-app/04-security.md)** — OWASP security headers, CSP policy, environment variable security, and testing procedures
-- **[Dependency Vulnerability Runbook](/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)** — Procedures for detecting, triaging, and remediating CVEs with MTTR targets
-- **[Secrets Incident Runbook](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)** — Deterministic response to suspected secret leaks or exfiltration
+- **[Security Hardening Implementation](/60-projects/portfolio-app/04-security.md)** — OWASP security headers, CSP policy, environment variable security, and testing procedures
+- **[Dependency Vulnerability Runbook](/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)** — Procedures for detecting, triaging, and remediating CVEs with MTTR targets
+- **[Secrets Incident Runbook](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)** — Deterministic response to suspected secret leaks or exfiltration
 
 **Portfolio App Dossier References:**
 
-- [Overview — Security Posture Hardening](/docs/60-projects/portfolio-app/01-overview.md)
-- [Architecture — Security References](/docs/60-projects/portfolio-app/02-architecture.md#out-of-scope)
-- [Operations — Security Monitoring](/docs/60-projects/portfolio-app/06-operations.md)
+- [Overview — Security Posture Hardening](/60-projects/portfolio-app/01-overview.md)
+- [Architecture — Security References](/60-projects/portfolio-app/02-architecture.md#out-of-scope)
+- [Operations — Security Monitoring](/60-projects/portfolio-app/06-operations.md)

--- a/docs/40-security/portfolio-app-security-controls.md
+++ b/docs/40-security/portfolio-app-security-controls.md
@@ -398,4 +398,4 @@ Automatic scanning on all PRs using TruffleHog:
 - [Content Security Policy (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 - [Next.js Security Headers](https://nextjs.org/docs/app/api-reference/next-config-js/headers)
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-- [Threat Model: Portfolio App](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)
+- [Threat Model: Portfolio App](/40-security/threat-models/portfolio-app-threat-model-v2.md)

--- a/docs/40-security/portfolio-docs-hardening-implementation-plan.md
+++ b/docs/40-security/portfolio-docs-hardening-implementation-plan.md
@@ -115,7 +115,7 @@ Define a bounded, docs-specific hardening plan for the Portfolio Docs app that m
 
 ## References
 
-- ADR-0019: [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
-- Security policies: [/docs/40-security/security-policies.md](/docs/40-security/security-policies.md)
-- Risk register: [/docs/40-security/risk-register.md](/docs/40-security/risk-register.md)
-- Security index: [/docs/40-security/](/docs/40-security/index.md)
+- ADR-0019: [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
+- Security policies: [/docs/40-security/security-policies.md](/40-security/security-policies.md)
+- Risk register: [/docs/40-security/risk-register.md](/40-security/risk-register.md)
+- Security index: [/docs/40-security/](/40-security/index.md)

--- a/docs/40-security/react2shell-hardening-implementation-guide.md
+++ b/docs/40-security/react2shell-hardening-implementation-guide.md
@@ -270,6 +270,6 @@ pnpm verify
 
 - React2Shell report: `/tmp/react2shell-report.md`
 - React2Shell hardening research: `/tmp/react2shell-hardening-research.md`
-- Security policies: [/docs/40-security/security-policies.md](/docs/40-security/security-policies.md)
-- Risk register: [/docs/40-security/risk-register.md](/docs/40-security/risk-register.md)
-- Portfolio App security controls: [/docs/40-security/portfolio-app-security-controls.md](/docs/40-security/portfolio-app-security-controls.md)
+- Security policies: [/docs/40-security/security-policies.md](/40-security/security-policies.md)
+- Risk register: [/docs/40-security/risk-register.md](/40-security/risk-register.md)
+- Portfolio App security controls: [/docs/40-security/portfolio-app-security-controls.md](/40-security/portfolio-app-security-controls.md)

--- a/docs/40-security/threat-models/portfolio-app-stride-compliance-report.md
+++ b/docs/40-security/threat-models/portfolio-app-stride-compliance-report.md
@@ -45,8 +45,8 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 **Evidence Artifacts:**
 
-- [Threat Model: Spoofing](/docs/40-security/threat-models/portfolio-app-threat-model.md#spoofing-identity)
-- [Dossier: Security](/docs/60-projects/portfolio-app/04-security.md)
+- [Threat Model: Spoofing](/40-security/threat-models/portfolio-app-threat-model.md#spoofing-identity)
+- [Dossier: Security](/60-projects/portfolio-app/04-security.md)
 
 ---
 
@@ -67,8 +67,8 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 **Evidence Artifacts:**
 
 - CI Workflow: [.github/workflows/ci.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml)
-- GitHub Rulesets: Verified in [rbk-vercel-setup-and-promotion-validation.md](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md)
-- Rollback Runbook: [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
+- GitHub Rulesets: Verified in [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md)
+- Rollback Runbook: [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md)
 
 ---
 
@@ -89,7 +89,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 - Updated CI Workflow: [.github/workflows/ci.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L1-L17) (permissions now scoped per job)
 - CodeQL Workflow: [.github/workflows/codeql.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/codeql.yml) (permissions: `contents: read`, `security-events: write`)
-- Threat Model: [Tampering — Threat 2](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-modifies-ci-workflows-or-build-scripts-to-inject-malicious-code)
+- Threat Model: [Tampering — Threat 2](/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-modifies-ci-workflows-or-build-scripts-to-inject-malicious-code)
 
 ---
 
@@ -129,7 +129,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 **Evidence Artifacts:**
 
 - PR Template: [.github/PULL_REQUEST_TEMPLATE.md](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/PULL_REQUEST_TEMPLATE.md) (requires context + security statement)
-- Threat Model: [Repudiation](/docs/40-security/threat-models/portfolio-app-threat-model.md#repudiation-accountability)
+- Threat Model: [Repudiation](/40-security/threat-models/portfolio-app-threat-model.md#repudiation-accountability)
 
 ---
 
@@ -172,7 +172,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 **Evidence Artifacts:**
 
 - CI Workflow: [.github/workflows/ci.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml) (no `env:` debug logging)
-- Threat Model: [Information Disclosure — Threat 2](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-reads-private-github-actions-logs-or-deployment-logs)
+- Threat Model: [Information Disclosure — Threat 2](/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-reads-private-github-actions-logs-or-deployment-logs)
 
 ---
 
@@ -192,7 +192,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 - Source Audit: [src/app/](https://github.com/bryce-seefieldt/portfolio-app/blob/main/src/app/) — all components are static; no dynamic HTML injection
 - Dependencies: [package.json](https://github.com/bryce-seefieldt/portfolio-app/blob/main/package.json) — no analytics or tracking libraries
-- Threat Model: [Information Disclosure — Threat 3](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-3-attacker-performs-content-injection-to-steal-data-or-redirect-users)
+- Threat Model: [Information Disclosure — Threat 3](/40-security/threat-models/portfolio-app-threat-model.md#threat-3-attacker-performs-content-injection-to-steal-data-or-redirect-users)
 
 ---
 
@@ -205,15 +205,15 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 | Vercel DDoS protection     | ✅       | ✅          | Built-in; Vercel dashboard shows DDoS protection enabled                                                    |
 | Static-first content model | ✅       | ✅          | No heavy compute per request; static Next.js optimization                                                   |
 | Minimal client JS          | ✅       | ✅          | **Target: < 50KB gzipped**; minimal React components (no heavy libraries)                                   |
-| Rollback readiness         | ✅       | ✅          | [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md) tested; ~1 min rollback |
+| Rollback readiness         | ✅       | ✅          | [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md) tested; ~1 min rollback |
 
 **Compliance Status:** ✅ **100% — All controls verified**
 
 **Evidence Artifacts:**
 
 - Vercel Config: [next.config.ts](https://github.com/bryce-seefieldt/portfolio-app/blob/main/next.config.ts) (React Compiler enabled for optimization)
-- Rollback Runbook: [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
-- Threat Model: [Denial of Service — Threat 1](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-1-attacker-floods-the-portfolio-app-domain-with-requests)
+- Rollback Runbook: [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md)
+- Threat Model: [Denial of Service — Threat 1](/40-security/threat-models/portfolio-app-threat-model.md#threat-1-attacker-floods-the-portfolio-app-domain-with-requests)
 
 ---
 
@@ -232,7 +232,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 - Smoke Tests: [tests/e2e/smoke.spec.ts](https://github.com/bryce-seefieldt/portfolio-app/blob/main/tests/e2e/smoke.spec.ts) (validates 12 routes; Chromium + Firefox)
 - CI Workflow: [.github/workflows/ci.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L96-L106) (smoke tests required)
-- Dossier: [02-architecture.md](/docs/60-projects/portfolio-app/02-architecture.md) (minimal JS strategy)
+- Dossier: [02-architecture.md](/60-projects/portfolio-app/02-architecture.md) (minimal JS strategy)
 
 ---
 
@@ -254,9 +254,9 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 **Evidence Artifacts:**
 
-- GitHub Rulesets: [rbk-vercel-setup-and-promotion-validation.md](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) (setup verified)
+- GitHub Rulesets: [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) (setup verified)
 - CI Workflow: [.github/workflows/ci.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L1-L17) (permissions scoped per Phase 2 enhancement)
-- Threat Model: [Elevation of Privilege — Threat 1](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-1-attacker-gains-elevated-permissions-in-the-github-organization-or-vercel)
+- Threat Model: [Elevation of Privilege — Threat 1](/40-security/threat-models/portfolio-app-threat-model.md#threat-1-attacker-gains-elevated-permissions-in-the-github-organization-or-vercel)
 
 ---
 
@@ -268,15 +268,15 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 | GitHub Rulesets require 1+ approval | ✅       | ✅          | Ruleset: `main-protection` enforces 1 approval minimum (configurable, currently 1)                                                                         |
 | Dismissal of stale reviews          | ✅       | ✅          | Enabled: stale reviews are dismissed if branch is updated                                                                                                  |
 | Required status checks              | ✅       | ✅          | Checks required: `ci / quality`, `ci / build`, `secrets-scan`, CodeQL (all must pass)                                                                      |
-| Reviewer guidance provided          | ✅       | ✅          | [ADR-0007](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) documents promotion gates and review responsibilities |
+| Reviewer guidance provided          | ✅       | ✅          | [ADR-0007](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) documents promotion gates and review responsibilities |
 
 **Compliance Status:** ✅ **100% — All controls verified**
 
 **Evidence Artifacts:**
 
 - PR Template: [.github/PULL_REQUEST_TEMPLATE.md](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
-- ADR: [ADR-0007: Portfolio App Hosting (Vercel) with Promotion Checks](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
-- Threat Model: [Elevation of Privilege — Threat 2](/docs/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-escalates-from-a-feature-branch-to-main-via-social-engineering-or-process-bypass)
+- ADR: [ADR-0007: Portfolio App Hosting (Vercel) with Promotion Checks](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
+- Threat Model: [Elevation of Privilege — Threat 2](/40-security/threat-models/portfolio-app-threat-model.md#threat-2-attacker-escalates-from-a-feature-branch-to-main-via-social-engineering-or-process-bypass)
 
 ---
 
@@ -290,7 +290,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 | **Least-Privilege CI Permissions**        | Tampering (T2), Elevation (E1)  | ✅ Complete | [ci.yml#L1-L17](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L1-L17)   |
 | **Pre-commit Hook (TruffleHog)**          | Information Disclosure (T1)     | ✅ Complete | [.pre-commit-config.yaml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.pre-commit-config.yaml) |
 | **Local Verification Scan**               | Information Disclosure (T1)     | ✅ Complete | Lightweight pattern-based scan; TruffleHog not run locally                                                    |
-| **Secrets Incident Runbook**              | Information Disclosure (T1, T2) | ✅ Complete | [rbk-portfolio-secrets-incident.md](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)           |
+| **Secrets Incident Runbook**              | Information Disclosure (T1, T2) | ✅ Complete | [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)           |
 
 ---
 
@@ -430,29 +430,29 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 ### Threat Model
 
-- Primary: [Portfolio App Threat Model (STRIDE)](/docs/40-security/threat-models/portfolio-app-threat-model.md)
+- Primary: [Portfolio App Threat Model (STRIDE)](/40-security/threat-models/portfolio-app-threat-model.md)
 
 ### Dossiers
 
-- [Portfolio App Security Dossier](/docs/60-projects/portfolio-app/04-security.md)
-- [Portfolio App Architecture Dossier](/docs/60-projects/portfolio-app/02-architecture.md)
+- [Portfolio App Security Dossier](/60-projects/portfolio-app/04-security.md)
+- [Portfolio App Architecture Dossier](/60-projects/portfolio-app/02-architecture.md)
 
 ### ADRs
 
-- [ADR-0005: Portfolio App Stack (Next.js + TypeScript)](/docs/10-architecture/adr/adr-0005-portfolio-app-stack-nextjs-ts.md)
-- [ADR-0007: Portfolio App Hosting (Vercel) with Promotion Checks](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
+- [ADR-0005: Portfolio App Stack (Next.js + TypeScript)](/10-architecture/adr/adr-0005-portfolio-app-stack-nextjs-ts.md)
+- [ADR-0007: Portfolio App Hosting (Vercel) with Promotion Checks](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
 
 ### Runbooks
 
-- [Deploy](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
-- [Rollback](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
-- [CI Triage](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
-- [Secrets Incident Response](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md) (Phase 2)
+- [Deploy](/50-operations/runbooks/rbk-portfolio-deploy.md)
+- [Rollback](/50-operations/runbooks/rbk-portfolio-rollback.md)
+- [CI Triage](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [Secrets Incident Response](/50-operations/runbooks/rbk-portfolio-secrets-incident.md) (Phase 2)
 
 ### Phase 2 Planning
 
-- [Phase 2 Implementation Guide](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
-- [Roadmap](/docs/00-portfolio/roadmap/index.md)
+- [Phase 2 Implementation Guide](/00-portfolio/roadmap/phase-2-implementation-guide.md)
+- [Roadmap](/00-portfolio/roadmap/index.md)
 
 ---
 

--- a/docs/40-security/threat-models/portfolio-app-stride-compliance-report.md
+++ b/docs/40-security/threat-models/portfolio-app-stride-compliance-report.md
@@ -200,11 +200,11 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 #### Threat 1: Attacker Floods Domain with Requests
 
-| Mitigation                 | Required | Implemented | Evidence                                                                                                    |
-| -------------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
-| Vercel DDoS protection     | ✅       | ✅          | Built-in; Vercel dashboard shows DDoS protection enabled                                                    |
-| Static-first content model | ✅       | ✅          | No heavy compute per request; static Next.js optimization                                                   |
-| Minimal client JS          | ✅       | ✅          | **Target: < 50KB gzipped**; minimal React components (no heavy libraries)                                   |
+| Mitigation                 | Required | Implemented | Evidence                                                                                               |
+| -------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| Vercel DDoS protection     | ✅       | ✅          | Built-in; Vercel dashboard shows DDoS protection enabled                                               |
+| Static-first content model | ✅       | ✅          | No heavy compute per request; static Next.js optimization                                              |
+| Minimal client JS          | ✅       | ✅          | **Target: < 50KB gzipped**; minimal React components (no heavy libraries)                              |
 | Rollback readiness         | ✅       | ✅          | [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md) tested; ~1 min rollback |
 
 **Compliance Status:** ✅ **100% — All controls verified**
@@ -262,12 +262,12 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 
 #### Threat 2: Attacker Escalates via Social Engineering or Process Bypass
 
-| Mitigation                          | Required | Implemented | Evidence                                                                                                                                                   |
-| ----------------------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PR template security checklist      | ✅       | ✅          | [PULL_REQUEST_TEMPLATE.md](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/PULL_REQUEST_TEMPLATE.md) includes mandatory checks          |
-| GitHub Rulesets require 1+ approval | ✅       | ✅          | Ruleset: `main-protection` enforces 1 approval minimum (configurable, currently 1)                                                                         |
-| Dismissal of stale reviews          | ✅       | ✅          | Enabled: stale reviews are dismissed if branch is updated                                                                                                  |
-| Required status checks              | ✅       | ✅          | Checks required: `ci / quality`, `ci / build`, `secrets-scan`, CodeQL (all must pass)                                                                      |
+| Mitigation                          | Required | Implemented | Evidence                                                                                                                                              |
+| ----------------------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PR template security checklist      | ✅       | ✅          | [PULL_REQUEST_TEMPLATE.md](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/PULL_REQUEST_TEMPLATE.md) includes mandatory checks     |
+| GitHub Rulesets require 1+ approval | ✅       | ✅          | Ruleset: `main-protection` enforces 1 approval minimum (configurable, currently 1)                                                                    |
+| Dismissal of stale reviews          | ✅       | ✅          | Enabled: stale reviews are dismissed if branch is updated                                                                                             |
+| Required status checks              | ✅       | ✅          | Checks required: `ci / quality`, `ci / build`, `secrets-scan`, CodeQL (all must pass)                                                                 |
 | Reviewer guidance provided          | ✅       | ✅          | [ADR-0007](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md) documents promotion gates and review responsibilities |
 
 **Compliance Status:** ✅ **100% — All controls verified**
@@ -290,7 +290,7 @@ The Portfolio App is **COMPLIANT** with baseline STRIDE mitigations and includes
 | **Least-Privilege CI Permissions**        | Tampering (T2), Elevation (E1)  | ✅ Complete | [ci.yml#L1-L17](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L1-L17)   |
 | **Pre-commit Hook (TruffleHog)**          | Information Disclosure (T1)     | ✅ Complete | [.pre-commit-config.yaml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.pre-commit-config.yaml) |
 | **Local Verification Scan**               | Information Disclosure (T1)     | ✅ Complete | Lightweight pattern-based scan; TruffleHog not run locally                                                    |
-| **Secrets Incident Runbook**              | Information Disclosure (T1, T2) | ✅ Complete | [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)           |
+| **Secrets Incident Runbook**              | Information Disclosure (T1, T2) | ✅ Complete | [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                |
 
 ---
 

--- a/docs/40-security/threat-models/portfolio-app-threat-model-v2.md
+++ b/docs/40-security/threat-models/portfolio-app-threat-model-v2.md
@@ -54,6 +54,6 @@ Stage 4.4 extends the Portfolio App threat model to include deployment surface a
 
 - Risk register: [docs/40-security/risk-register.md](docs/40-security/risk-register.md)
 - Security policies: [docs/40-security/security-policies.md](docs/40-security/security-policies.md)
-- Security hardening guide: [Security hardening dossier](/docs/60-projects/portfolio-app/04-security.md)
+- Security hardening guide: [Security hardening dossier](/60-projects/portfolio-app/04-security.md)
 - Dependency vulnerability runbook: [docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md](docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)
 - Validate headers/CSP: `curl -I https://example.com/` and browser DevTools (no CSP violations)

--- a/docs/40-security/threat-models/portfolio-app-threat-model.md
+++ b/docs/40-security/threat-models/portfolio-app-threat-model.md
@@ -412,8 +412,8 @@ STRIDE categories: **S**poofing (identity), **T**ampering (data integrity), **R*
 
 ### Production availability issue
 
-1. Follow [rbk-portfolio-ci-triage.md](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
-2. Use [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md) if needed
+1. Follow [rbk-portfolio-ci-triage.md](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+2. Use [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md) if needed
 3. Post-incident: Review and update runbooks
 
 ---
@@ -422,25 +422,25 @@ STRIDE categories: **S**poofing (identity), **T**ampering (data integrity), **R*
 
 ### Portfolio App Dossier
 
-- [Security](/docs/60-projects/portfolio-app/04-security.md)
-- [Deployment](/docs/60-projects/portfolio-app/03-deployment.md)
-- [Architecture](/docs/60-projects/portfolio-app/02-architecture.md)
+- [Security](/60-projects/portfolio-app/04-security.md)
+- [Deployment](/60-projects/portfolio-app/03-deployment.md)
+- [Architecture](/60-projects/portfolio-app/02-architecture.md)
 
 ### Architecture Decision Records (ADRs)
 
-- [ADR-0005: Portfolio App Stack (Next.js + TypeScript)](/docs/10-architecture/adr/adr-0005-portfolio-app-stack-nextjs-ts.md)
-- [ADR-0006: Separate Portfolio App from Evidence Engine (Docs)](/docs/10-architecture/adr/adr-0006-separate-portfolio-app-from-evidence-engine-docs.md)
-- [ADR-0007: Portfolio App Hosting (Vercel) with Promotion Checks](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
+- [ADR-0005: Portfolio App Stack (Next.js + TypeScript)](/10-architecture/adr/adr-0005-portfolio-app-stack-nextjs-ts.md)
+- [ADR-0006: Separate Portfolio App from Evidence Engine (Docs)](/10-architecture/adr/adr-0006-separate-portfolio-app-from-evidence-engine-docs.md)
+- [ADR-0007: Portfolio App Hosting (Vercel) with Promotion Checks](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
 
 ### Operational Runbooks
 
 60-projects/portfolio-app
 
-- [Deploy](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)
-- [Rollback](/docs/50-operations/runbooks/rbk-portfolio-rollback.md)
-- [CI Triage](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [Deploy](/50-operations/runbooks/rbk-portfolio-deploy.md)
+- [Rollback](/50-operations/runbooks/rbk-portfolio-rollback.md)
+- [CI Triage](/50-operations/runbooks/rbk-portfolio-ci-triage.md)
 
 ### Phase 2 Planning
 
-- [Roadmap](/docs/00-portfolio/roadmap/index.md)
-- [Implementation Guide](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
+- [Roadmap](/00-portfolio/roadmap/index.md)
+- [Implementation Guide](/00-portfolio/roadmap/phase-2-implementation-guide.md)

--- a/docs/50-operations/incident-response/incident-handbook.md
+++ b/docs/50-operations/incident-response/incident-handbook.md
@@ -30,8 +30,8 @@ Provide a consolidated incident response handbook that supports on-call responde
 
 Match your scenario to the appropriate runbook:
 
-| I'm seeing...                              | Use this runbook                                                                                            |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| I'm seeing...                              | Use this runbook                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | ❌ Deployment shows "Failed" in Vercel     | [Deployment Failure](/50-operations/runbooks/rbk-portfolio-deployment-failure.md)                      |
 | ⚠️ Health endpoint returns 503             | [Service Degradation](/50-operations/runbooks/rbk-portfolio-service-degradation.md)                    |
 | 🔴 All routes return 500                   | [Deployment Failure](/50-operations/runbooks/rbk-portfolio-deployment-failure.md)                      |

--- a/docs/50-operations/incident-response/incident-handbook.md
+++ b/docs/50-operations/incident-response/incident-handbook.md
@@ -7,7 +7,7 @@ tags: [operations, incident-response, runbook, handbook, reliability]
 
 ## Purpose
 
-Provide a consolidated incident response handbook that supports on-call responders with severity guidance, quick selectors, and operational patterns. This handbook complements the runbook catalog at [/docs/50-operations/runbooks](/docs/50-operations/runbooks/index.md).
+Provide a consolidated incident response handbook that supports on-call responders with severity guidance, quick selectors, and operational patterns. This handbook complements the runbook catalog at [/docs/50-operations/runbooks](/50-operations/runbooks/index.md).
 
 ## Scope
 
@@ -32,17 +32,17 @@ Match your scenario to the appropriate runbook:
 
 | I'm seeing...                              | Use this runbook                                                                                            |
 | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| ❌ Deployment shows "Failed" in Vercel     | [Deployment Failure](/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md)                      |
-| ⚠️ Health endpoint returns 503             | [Service Degradation](/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md)                    |
-| 🔴 All routes return 500                   | [Deployment Failure](/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md)                      |
-| 🐌 Pages load slowly (>3s) but no errors   | [Performance Troubleshooting](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)    |
-| 📦 Bundle size too large (>30MB)           | [Performance Troubleshooting](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)    |
-| ❓ Unclear incident, need framework        | [General Incident Response](/docs/50-operations/runbooks/rbk-portfolio-incident-response.md)                |
-| 🔍 Want to understand monitoring setup     | [Observability & Health Checks](/docs/30-devops-platform/observability-health-checks.md)                    |
-| ⚡ Want to improve performance proactively | [Performance Optimization](/docs/50-operations/runbooks/rbk-portfolio-performance-optimization.md)          |
-| 🔐 CVE alert or dependency vulnerability   | [Dependency Vulnerability Response](/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md) |
-| 🤖 Dependabot PR checks are failing        | [Dependabot PR CI Remediation](/docs/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md)            |
-| 🚨 Suspected secret leak in repo           | [Secrets Incident Response](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                 |
+| ❌ Deployment shows "Failed" in Vercel     | [Deployment Failure](/50-operations/runbooks/rbk-portfolio-deployment-failure.md)                      |
+| ⚠️ Health endpoint returns 503             | [Service Degradation](/50-operations/runbooks/rbk-portfolio-service-degradation.md)                    |
+| 🔴 All routes return 500                   | [Deployment Failure](/50-operations/runbooks/rbk-portfolio-deployment-failure.md)                      |
+| 🐌 Pages load slowly (>3s) but no errors   | [Performance Troubleshooting](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)    |
+| 📦 Bundle size too large (>30MB)           | [Performance Troubleshooting](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)    |
+| ❓ Unclear incident, need framework        | [General Incident Response](/50-operations/runbooks/rbk-portfolio-incident-response.md)                |
+| 🔍 Want to understand monitoring setup     | [Observability & Health Checks](/30-devops-platform/observability-health-checks.md)                    |
+| ⚡ Want to improve performance proactively | [Performance Optimization](/50-operations/runbooks/rbk-portfolio-performance-optimization.md)          |
+| 🔐 CVE alert or dependency vulnerability   | [Dependency Vulnerability Response](/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md) |
+| 🤖 Dependabot PR checks are failing        | [Dependabot PR CI Remediation](/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md)            |
+| 🚨 Suspected secret leak in repo           | [Secrets Incident Response](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                 |
 
 ---
 
@@ -56,14 +56,14 @@ Match your scenario to the appropriate runbook:
 
 1. **Page on-call engineer + VP Engineering** (Slack + SMS + phone)
 2. **Create incident channel:** `#incident-INC-YYYYMMDD-NNN`
-3. **Execute runbook:** [Deployment Failure](/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md) if recent deployment, otherwise [General Incident Response](/docs/50-operations/runbooks/rbk-portfolio-incident-response.md)
+3. **Execute runbook:** [Deployment Failure](/50-operations/runbooks/rbk-portfolio-deployment-failure.md) if recent deployment, otherwise [General Incident Response](/50-operations/runbooks/rbk-portfolio-incident-response.md)
 4. **Post updates every 5 minutes**
 5. **All-clear when resolved**
 6. **Schedule postmortem within 24 hours**
 
 **MTTR Target:** 15 minutes
 
-**If Secrets Incident:** Execute [Secrets Incident Response](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md) immediately; MTTR ≤5 min for critical secrets
+**If Secrets Incident:** Execute [Secrets Incident Response](/50-operations/runbooks/rbk-portfolio-secrets-incident.md) immediately; MTTR ≤5 min for critical secrets
 
 ### High Severity (SEV-2) — Urgent Response
 
@@ -72,14 +72,14 @@ Match your scenario to the appropriate runbook:
 **Quick Steps:**
 
 1. **Notify on-call engineer via Slack + PagerDuty**
-2. **Execute runbook:** [Service Degradation](/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md) or [Deployment Failure](/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md)
+2. **Execute runbook:** [Service Degradation](/50-operations/runbooks/rbk-portfolio-service-degradation.md) or [Deployment Failure](/50-operations/runbooks/rbk-portfolio-deployment-failure.md)
 3. **Target resolution:** less than 1 hour
 4. **Post updates every 10 minutes**
 5. **Schedule postmortem within 48 hours**
 
 **MTTR Target:** 1 hour
 
-**If Dependency CVE (High):** Execute [Dependency Vulnerability Response](/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md); MTTR 48 hours
+**If Dependency CVE (High):** Execute [Dependency Vulnerability Response](/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md); MTTR 48 hours
 
 ### Medium Severity (SEV-3) — Normal Response
 
@@ -89,7 +89,7 @@ Match your scenario to the appropriate runbook:
 
 1. **Notify team lead via Slack**
 2. **Create GitHub issue** to track
-3. **Execute runbook:** [Service Degradation](/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md) or [Performance Troubleshooting](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)
+3. **Execute runbook:** [Service Degradation](/50-operations/runbooks/rbk-portfolio-service-degradation.md) or [Performance Troubleshooting](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)
 4. **Investigate during business hours**
 5. **No formal postmortem** (document learnings in issue)
 

--- a/docs/50-operations/incident-response/index.md
+++ b/docs/50-operations/incident-response/index.md
@@ -48,7 +48,7 @@ Incident responders should know:
 
 Severity must map to user impact and recovery urgency. Use the severity guidance in the handbook:
 
-- [Incident Response Handbook](/docs/50-operations/incident-response/incident-handbook.md)
+- [Incident Response Handbook](/50-operations/incident-response/incident-handbook.md)
 
 ## Communications (Minimum Standard)
 
@@ -68,7 +68,7 @@ Incidents must reference:
 
 ## References
 
-- Runbook catalog: [/docs/50-operations/runbooks/index.md](/docs/50-operations/runbooks/index.md)
-- Incident handbook: [/docs/50-operations/incident-response/incident-handbook.md](/docs/50-operations/incident-response/incident-handbook.md)
+- Runbook catalog: [/docs/50-operations/runbooks/index.md](/50-operations/runbooks/index.md)
+- Incident handbook: [/docs/50-operations/incident-response/incident-handbook.md](/50-operations/incident-response/incident-handbook.md)
 - Postmortem template: [/docs/\_meta/templates/template-postmortem.md](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/docs/_meta/templates/template-postmortem.md)
-- Observability & health checks: [/docs/30-devops-platform/observability-health-checks.md](/docs/30-devops-platform/observability-health-checks.md)
+- Observability & health checks: [/docs/30-devops-platform/observability-health-checks.md](/30-devops-platform/observability-health-checks.md)

--- a/docs/50-operations/index.md
+++ b/docs/50-operations/index.md
@@ -86,7 +86,7 @@ See **[Runbooks Index](./runbooks/index.md)** for operational procedures:
 - **[Service Degradation](./runbooks/rbk-portfolio-service-degradation.md)** — Diagnose and resolve performance/availability issues (MTTR: 10 min)
 - **[Deployment Failure Recovery](./runbooks/rbk-portfolio-deployment-failure.md)** — Detect and rollback failed deployments (MTTR: 5 min)
 
-For observability architecture and monitoring setup, see [Observability & Health Checks](/docs/30-devops-platform/observability-health-checks.md).
+For observability architecture and monitoring setup, see [Observability & Health Checks](/30-devops-platform/observability-health-checks.md).
 
 ## References
 

--- a/docs/50-operations/runbooks/index.md
+++ b/docs/50-operations/runbooks/index.md
@@ -222,8 +222,8 @@ Runbooks should be your first reference during:
 
 ### Operational Readiness
 
-| Document                                                                                  | Purpose                                         | Audience                    |
-| ----------------------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------- |
+| Document                                                                             | Purpose                                         | Audience                    |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------- | --------------------------- |
 | **[Observability & Monitoring](/30-devops-platform/observability-health-checks.md)** | Health checks, logging, monitoring architecture | Developers, DevOps, On-call |
 
 ---

--- a/docs/50-operations/runbooks/index.md
+++ b/docs/50-operations/runbooks/index.md
@@ -138,7 +138,7 @@ Runbooks should be your first reference during:
 
 ### How to Use Runbooks During an Incident
 
-1. **Identify the scenario** — Match symptoms to runbook using the [Incident Response Handbook](/docs/50-operations/incident-response/incident-handbook.md)
+1. **Identify the scenario** — Match symptoms to runbook using the [Incident Response Handbook](/50-operations/incident-response/incident-handbook.md)
 2. **Follow steps sequentially** — Don't skip steps unless explicitly told to
 3. **Track progress** — Check off completed steps, note timestamps
 4. **Escalate when indicated** — Follow escalation procedures if MTTR target missed
@@ -224,7 +224,7 @@ Runbooks should be your first reference during:
 
 | Document                                                                                  | Purpose                                         | Audience                    |
 | ----------------------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------- |
-| **[Observability & Monitoring](/docs/30-devops-platform/observability-health-checks.md)** | Health checks, logging, monitoring architecture | Developers, DevOps, On-call |
+| **[Observability & Monitoring](/30-devops-platform/observability-health-checks.md)** | Health checks, logging, monitoring architecture | Developers, DevOps, On-call |
 
 ---
 
@@ -232,4 +232,4 @@ Runbooks should be your first reference during:
 
 For severity guidance, quick selectors, and operational patterns, use the incident handbook:
 
-- [Incident Response Handbook](/docs/50-operations/incident-response/incident-handbook.md)
+- [Incident Response Handbook](/50-operations/incident-response/incident-handbook.md)

--- a/docs/50-operations/runbooks/rbk-docs-deploy.md
+++ b/docs/50-operations/runbooks/rbk-docs-deploy.md
@@ -336,7 +336,7 @@ pnpm policy:check
 
 - TypeScript upgrade failures (for example `TS5101` deprecation errors) can require tsconfig migration updates rather than application code changes.
 
-For end-to-end bot PR recovery procedure, see [Dependabot PR CI Remediation](/docs/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md).
+For end-to-end bot PR recovery procedure, see [Dependabot PR CI Remediation](/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md).
 
 ### Failure: Output directory mismatch (404 errors or missing pages)
 

--- a/docs/50-operations/runbooks/rbk-portfolio-archival.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-archival.md
@@ -116,6 +116,6 @@ If validation fails, revert the archival changes and correct links before retryi
 
 ## References
 
-- Portfolio archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/docs/00-portfolio/portfolio-archival-policy.md)
-- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/docs/00-portfolio/portfolio-change-intake.md)
-- Release notes: [/docs/00-portfolio/release-notes/index.md](/docs/00-portfolio/release-notes/index.md)
+- Portfolio archival policy: [/docs/00-portfolio/portfolio-archival-policy.md](/00-portfolio/portfolio-archival-policy.md)
+- Change intake checklist: [/docs/00-portfolio/portfolio-change-intake.md](/00-portfolio/portfolio-change-intake.md)
+- Release notes: [/docs/00-portfolio/release-notes/index.md](/00-portfolio/release-notes/index.md)

--- a/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md
@@ -371,7 +371,7 @@ git push
 
 If push is rejected, create a maintainer branch from the checked-out state and open a replacement PR that references the Dependabot PR.
 
-For full responder flow and cross-repo check matrix, see [Dependabot PR CI Remediation](/docs/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md).
+For full responder flow and cross-repo check matrix, see [Dependabot PR CI Remediation](/50-operations/runbooks/rbk-dependabot-pr-ci-remediation.md).
 
 #### 5) Validate and push fix
 

--- a/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md
@@ -582,7 +582,7 @@ vercel ls | head -5
 ### External Links
 
 - [Vercel Deployments](https://vercel.com/bryce-seefieldts-projects/portfolio-app/deployments)
-- [Observability & Health Checks](/docs/30-devops-platform/observability-health-checks.md)
+- [Observability & Health Checks](/30-devops-platform/observability-health-checks.md)
 
 ### Related Runbooks
 

--- a/docs/50-operations/runbooks/rbk-portfolio-incident-response.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-incident-response.md
@@ -492,7 +492,7 @@ gh issue create \
 - [Deployment Failure](./rbk-portfolio-deployment-failure.md)
 - [Performance Optimization](./rbk-portfolio-performance-optimization.md)
 - [Performance Troubleshooting](./rbk-portfolio-performance-troubleshooting.md)
-- [Observability & Health Checks](/docs/30-devops-platform/observability-health-checks.md)
+- [Observability & Health Checks](/30-devops-platform/observability-health-checks.md)
 
 ---
 

--- a/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md
@@ -18,7 +18,7 @@ This is a **"stop-the-line" incident** requiring immediate action to:
 
 ## Governance Context
 
-This runbook implements the threat model's [Incident Response / Suspected secret publication](/docs/40-security/threat-models/portfolio-app-threat-model.md#incident-response) procedure. All actions assume:
+This runbook implements the threat model's [Incident Response / Suspected secret publication](/40-security/threat-models/portfolio-app-threat-model.md#incident-response) procedure. All actions assume:
 
 - GitHub Actions logs are retained and auditable
 - Vercel deployments are immutable and traceable to Git commits
@@ -349,7 +349,7 @@ Create `docs/_meta/postmortem-YYYY-MM-DD-secrets-incident.md`:
 
 #### 5b) Update threat model (if needed)
 
-If the incident reveals a new threat or mitigation gap, update [portfolio-app-threat-model.md](/docs/40-security/threat-models/portfolio-app-threat-model.md):
+If the incident reveals a new threat or mitigation gap, update [portfolio-app-threat-model.md](/40-security/threat-models/portfolio-app-threat-model.md):
 
 1. Add the threat if not already covered
 2. Document new mitigations
@@ -384,7 +384,7 @@ If the incident reveals a new threat or mitigation gap, update [portfolio-app-th
 
 ### Need help?
 
-- Refer to threat model: [Incident Response](/docs/40-security/threat-models/portfolio-app-threat-model.md#incident-response)
+- Refer to threat model: [Incident Response](/40-security/threat-models/portfolio-app-threat-model.md#incident-response)
 - Refer to rollback runbook: [rbk-portfolio-rollback.md](./rbk-portfolio-rollback.md)
 - Consult team / escalate if severity is unclear
 
@@ -436,7 +436,7 @@ If the incident reveals a new threat or mitigation gap, update [portfolio-app-th
 
 ## References
 
-- Threat Model: [Incident Response](/docs/40-security/threat-models/portfolio-app-threat-model.md#incident-response)
+- Threat Model: [Incident Response](/40-security/threat-models/portfolio-app-threat-model.md#incident-response)
 - Rollback Runbook: [rbk-portfolio-rollback.md](./rbk-portfolio-rollback.md)
 - CI Triage Runbook: [rbk-portfolio-ci-triage.md](./rbk-portfolio-ci-triage.md)
-- Phase 2 Implementation: [phase-2-implementation-guide.md](/docs/00-portfolio/roadmap/phase-2-implementation-guide.md)
+- Phase 2 Implementation: [phase-2-implementation-guide.md](/00-portfolio/roadmap/phase-2-implementation-guide.md)

--- a/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
@@ -626,7 +626,7 @@ vercel ls
 - [Vercel Deployments](https://vercel.com/bryce-seefieldts-projects/portfolio-app/deployments)
 - [Vercel Logs](https://vercel.com/bryce-seefieldts-projects/portfolio-app/logs)
 - [GitHub Repository](https://github.com/bryce-seefieldt/portfolio-app)
-- [Observability & Health Checks](/docs/30-devops-platform/observability-health-checks.md)
+- [Observability & Health Checks](/30-devops-platform/observability-health-checks.md)
 
 ### Related Runbooks
 

--- a/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
+++ b/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
@@ -51,12 +51,12 @@ This runbook implements the decision in [ADR-0007: Host Portfolio App on Vercel 
 
 ### Key constants (from documentation)
 
-| Item                          | Value                                                                               | Reference                                                           |
-| ----------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Item                          | Value                                                                               | Reference                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | **Required CI checks**        | `ci / quality`, `ci / build`                                                        | [CI workflow](/70-reference/portfolio-app-config-reference.md) |
-| **Environment variables**     | See Environment Variable Contract (`/docs/_meta/env/portfolio-app-env-contract.md`) | `.env.example` in repo                                              |
-| **Docs base URL (local dev)** | `http://localhost:3001`                                                             | Portfolio Docs local default                                        |
-| **Documentation repo URL**    | (URL of portfolio-docs Vercel deployment)                                           | To be determined during setup                                       |
+| **Environment variables**     | See Environment Variable Contract (`/docs/_meta/env/portfolio-app-env-contract.md`) | `.env.example` in repo                                         |
+| **Docs base URL (local dev)** | `http://localhost:3001`                                                             | Portfolio Docs local default                                   |
+| **Documentation repo URL**    | (URL of portfolio-docs Vercel deployment)                                           | To be determined during setup                                  |
 
 ## Procedure / Content
 

--- a/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
+++ b/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
@@ -53,7 +53,7 @@ This runbook implements the decision in [ADR-0007: Host Portfolio App on Vercel 
 
 | Item                          | Value                                                                               | Reference                                                           |
 | ----------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| **Required CI checks**        | `ci / quality`, `ci / build`                                                        | [CI workflow](/docs/70-reference/portfolio-app-config-reference.md) |
+| **Required CI checks**        | `ci / quality`, `ci / build`                                                        | [CI workflow](/70-reference/portfolio-app-config-reference.md) |
 | **Environment variables**     | See Environment Variable Contract (`/docs/_meta/env/portfolio-app-env-contract.md`) | `.env.example` in repo                                              |
 | **Docs base URL (local dev)** | `http://localhost:3001`                                                             | Portfolio Docs local default                                        |
 | **Documentation repo URL**    | (URL of portfolio-docs Vercel deployment)                                           | To be determined during setup                                       |
@@ -770,7 +770,7 @@ NEXT_PUBLIC_DOCS_GITHUB_URL=https://github.com/bryce-seefieldt/portfolio-docs
 ## Related artifacts
 
 - [ADR-0007: Portfolio App Hosting on Vercel](docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
-- [Portfolio App Deployment Dossier](/docs/60-projects/portfolio-app/03-deployment.md)
-- [Portfolio App Config Reference](/docs/70-reference/portfolio-app-config-reference.md)
+- [Portfolio App Deployment Dossier](/60-projects/portfolio-app/03-deployment.md)
+- [Portfolio App Config Reference](/70-reference/portfolio-app-config-reference.md)
 - Portfolio App Environment Contract (`/docs/_meta/env/portfolio-app-env-contract.md`)
-- [CI Triage Runbook](/docs/50-operations/runbooks/rbk-portfolio-ci-triage.md)
+- [CI Triage Runbook](/50-operations/runbooks/rbk-portfolio-ci-triage.md)

--- a/docs/60-projects/index.md
+++ b/docs/60-projects/index.md
@@ -17,14 +17,14 @@ This section contains project-specific dossiers. Each dossier is a structured pa
 
 ## Start here (reviewer path)
 
-1. Portfolio App dossier: [/docs/60-projects/portfolio-app/index.md](/docs/60-projects/portfolio-app/index.md)
-2. Portfolio Docs App dossier: [/docs/60-projects/portfolio-docs-app/index.md](/docs/60-projects/portfolio-docs-app/index.md)
+1. Portfolio App dossier: [/docs/60-projects/portfolio-app/index.md](/60-projects/portfolio-app/index.md)
+2. Portfolio Docs App dossier: [/docs/60-projects/portfolio-docs-app/index.md](/60-projects/portfolio-docs-app/index.md)
 3. Validate cross-cutting evidence:
 
-- ADRs: [/docs/10-architecture/adr/index.md](/docs/10-architecture/adr/index.md)
-- Threat models: [/docs/40-security/threat-models/index.md](/docs/40-security/threat-models/index.md)
-- Runbooks: [/docs/50-operations/runbooks/index.md](/docs/50-operations/runbooks/index.md)
-- Evidence checklist: [/docs/70-reference/evidence-audit-checklist.md](/docs/70-reference/evidence-audit-checklist.md)
+- ADRs: [/docs/10-architecture/adr/index.md](/10-architecture/adr/index.md)
+- Threat models: [/docs/40-security/threat-models/index.md](/40-security/threat-models/index.md)
+- Runbooks: [/docs/50-operations/runbooks/index.md](/50-operations/runbooks/index.md)
+- Evidence checklist: [/docs/70-reference/evidence-audit-checklist.md](/70-reference/evidence-audit-checklist.md)
 
 ## Scope
 

--- a/docs/60-projects/portfolio-app/01-overview.md
+++ b/docs/60-projects/portfolio-app/01-overview.md
@@ -113,7 +113,7 @@ The Portfolio App introduces a reusable component library for standardized evide
 
 Together, these components embed evidence verification into the user experience, making "show your work" a visual, interactive expectation rather than a hidden link hunt.
 
-See [Architecture — Evidence Visualization Layer](/docs/60-projects/portfolio-app/02-architecture.md) for full details.
+See [Architecture — Evidence Visualization Layer](/60-projects/portfolio-app/02-architecture.md) for full details.
 
 ### Security Posture Hardening
 
@@ -127,7 +127,7 @@ The portfolio app security posture includes OWASP-recommended HTTP security head
 - Threat model v2 covering deployment, runtime, and supply chain threats
 - Formal dependency vulnerability audit policy with MTTR targets
 
-See [Security Hardening Documentation](/docs/60-projects/portfolio-app/04-security.md) for implementation details.
+See [Security Hardening Documentation](/60-projects/portfolio-app/04-security.md) for implementation details.
 
 ### User Experience & SEO Optimization
 
@@ -150,9 +150,9 @@ See comprehensive documentation in domain sections:
 
 See architectural decisions (ADRs):
 
-- [ADR-0014: Class-Based Dark Mode with CSS Variables](/docs/10-architecture/adr/adr-0014-class-based-dark-mode.md) - Class-based theming rationale
-- [ADR-0015: Open Graph + Twitter Cards + JSON-LD](/docs/10-architecture/adr/adr-0015-metadata-strategy.md) - Tri-layer metadata strategy
-- [ADR-0016: Scroll Animation Strategy (Intersection Observer)](/docs/10-architecture/adr/adr-0016-scroll-animations.md) - Performance-first animations
+- [ADR-0014: Class-Based Dark Mode with CSS Variables](/10-architecture/adr/adr-0014-class-based-dark-mode.md) - Class-based theming rationale
+- [ADR-0015: Open Graph + Twitter Cards + JSON-LD](/10-architecture/adr/adr-0015-metadata-strategy.md) - Tri-layer metadata strategy
+- [ADR-0016: Scroll Animation Strategy (Intersection Observer)](/10-architecture/adr/adr-0016-scroll-animations.md) - Performance-first animations
 
 ## Validation / Expected outcomes
 
@@ -256,7 +256,7 @@ The Portfolio App implements a comprehensive testing pyramid:
 - **Coverage targets:** ≥80% for `src/lib/` (utility functions), 100% route coverage for E2E
 - **CI integration:** Tests run on every PR and merge; failures block deployment
 
-See [Testing Guide](/docs/reference/testing-guide) for comprehensive patterns, setup, and troubleshooting. Implementation details are available in [Testing](/docs/60-projects/portfolio-app/05-testing.md).
+See [Testing Guide](/reference/testing-guide) for comprehensive patterns, setup, and troubleshooting. Implementation details are available in [Testing](/60-projects/portfolio-app/05-testing.md).
 
 ### Code Quality Gates
 
@@ -292,7 +292,7 @@ All jobs must pass; failures block subsequent stages. Tests are separated into d
 - **Unit tests** validate data integrity, link construction, and slug validation
 - **E2E tests** validate route rendering, evidence-link DOM/href assertions, and component behavior
 
-See [CI/CD Pipeline Overview](/docs/devops-platform/ci-cd-pipeline-overview) for detailed job configuration and troubleshooting.
+See [CI/CD Pipeline Overview](/devops-platform/ci-cd-pipeline-overview) for detailed job configuration and troubleshooting.
 
 ### Evidence of Quality
 

--- a/docs/60-projects/portfolio-app/02-architecture.md
+++ b/docs/60-projects/portfolio-app/02-architecture.md
@@ -25,7 +25,7 @@ Describe the Portfolio App architecture at a level that is:
 ### Out of scope
 
 - CI/CD implementation details (see `deployment.md`)
-- security threat enumeration (see [threat-models/portfolio-app-threat-model-v2.md](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md))
+- security threat enumeration (see [threat-models/portfolio-app-threat-model-v2.md](/40-security/threat-models/portfolio-app-threat-model-v2.md))
 
 ## Prereqs / Inputs
 
@@ -475,8 +475,8 @@ This ensures broken tests prevent production deployments.
 
 #### See Also
 
-- **Testing Guide**: [docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md) — Comprehensive patterns and examples
-- **Testing Dossier**: [docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md) — CI gates and local validation
+- **Testing Guide**: [docs/70-reference/testing-guide.md](/70-reference/testing-guide.md) — Comprehensive patterns and examples
+- **Testing Dossier**: [docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md) — CI gates and local validation
 
 ### Evidence-link strategy
 

--- a/docs/60-projects/portfolio-app/03-deployment.md
+++ b/docs/60-projects/portfolio-app/03-deployment.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 tags: [projects, deployment, cicd, vercel, github-actions, governance]
 ---
 
-**Deployment posture:** Three-tier deployment model (Preview → Staging → Production) with staging domain mapping; CI quality/build/test gates; Vercel Deployment Checks; GitHub Ruleset protection on main and staging branches (see [rbk-vercel-setup-and-promotion-validation.md](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) and [rbk-portfolio-deploy.md](/docs/50-operations/runbooks/rbk-portfolio-deploy.md)).
+**Deployment posture:** Three-tier deployment model (Preview → Staging → Production) with staging domain mapping; CI quality/build/test gates; Vercel Deployment Checks; GitHub Ruleset protection on main and staging branches (see [rbk-vercel-setup-and-promotion-validation.md](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md) and [rbk-portfolio-deploy.md](/50-operations/runbooks/rbk-portfolio-deploy.md)).
 
 ## Purpose
 
@@ -431,7 +431,7 @@ git merge main
 git push origin staging
 ```
 
-See [rbk-portfolio-rollback.md](/docs/50-operations/runbooks/rbk-portfolio-rollback.md) for detailed rollback procedures.
+See [rbk-portfolio-rollback.md](/50-operations/runbooks/rbk-portfolio-rollback.md) for detailed rollback procedures.
 
 ### Staging Branch Maintenance
 

--- a/docs/60-projects/portfolio-app/04-security.md
+++ b/docs/60-projects/portfolio-app/04-security.md
@@ -222,8 +222,8 @@ grep -r "NEXT_PUBLIC.*SECRET\|NEXT_PUBLIC.*KEY\|NEXT_PUBLIC.*TOKEN" src/
 | Least-privilege CI perms | ✅ Enforced  | [ci.yml job permissions](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L19-L22)   |
 | CodeQL scanning          | ✅ Enforced  | [codeql.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/codeql.yml)                   |
 | Dependabot updates       | ✅ Enabled   | [dependabot.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/dependabot.yml)                     |
-| Threat model             | ✅ Complete  | [portfolio-app-threat-model-v2.md](/40-security/threat-models/portfolio-app-threat-model-v2.md)                    |
-| Incident response        | ✅ Ready     | [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                     |
+| Threat model             | ✅ Complete  | [portfolio-app-threat-model-v2.md](/40-security/threat-models/portfolio-app-threat-model-v2.md)                         |
+| Incident response        | ✅ Ready     | [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                          |
 | Unit tests               | ✅ Enforced  | [src/lib/**tests**/](https://github.com/bryce-seefieldt/portfolio-app/tree/main/src/lib/__tests__)                      |
 | E2E tests                | ✅ Enforced  | [tests/e2e](https://github.com/bryce-seefieldt/portfolio-app/tree/main/tests/e2e)                                       |
 | Frozen lockfiles         | ✅ Enforced  | [ci.yml build step](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml)                |

--- a/docs/60-projects/portfolio-app/04-security.md
+++ b/docs/60-projects/portfolio-app/04-security.md
@@ -37,7 +37,7 @@ The security objective is to demonstrate credible enterprise practices:
 
 ## Threat Model Reference
 
-**Comprehensive threat analysis:** See [Threat Model: Portfolio App](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)
+**Comprehensive threat analysis:** See [Threat Model: Portfolio App](/40-security/threat-models/portfolio-app-threat-model-v2.md)
 
 The dedicated threat model uses the **STRIDE** methodology to enumerate threats across six categories:
 
@@ -222,8 +222,8 @@ grep -r "NEXT_PUBLIC.*SECRET\|NEXT_PUBLIC.*KEY\|NEXT_PUBLIC.*TOKEN" src/
 | Least-privilege CI perms | ✅ Enforced  | [ci.yml job permissions](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml#L19-L22)   |
 | CodeQL scanning          | ✅ Enforced  | [codeql.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/codeql.yml)                   |
 | Dependabot updates       | ✅ Enabled   | [dependabot.yml](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/dependabot.yml)                     |
-| Threat model             | ✅ Complete  | [portfolio-app-threat-model-v2.md](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)                    |
-| Incident response        | ✅ Ready     | [rbk-portfolio-secrets-incident.md](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                     |
+| Threat model             | ✅ Complete  | [portfolio-app-threat-model-v2.md](/40-security/threat-models/portfolio-app-threat-model-v2.md)                    |
+| Incident response        | ✅ Ready     | [rbk-portfolio-secrets-incident.md](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)                     |
 | Unit tests               | ✅ Enforced  | [src/lib/**tests**/](https://github.com/bryce-seefieldt/portfolio-app/tree/main/src/lib/__tests__)                      |
 | E2E tests                | ✅ Enforced  | [tests/e2e](https://github.com/bryce-seefieldt/portfolio-app/tree/main/tests/e2e)                                       |
 | Frozen lockfiles         | ✅ Enforced  | [ci.yml build step](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml)                |

--- a/docs/60-projects/portfolio-app/05-testing.md
+++ b/docs/60-projects/portfolio-app/05-testing.md
@@ -537,7 +537,7 @@ After running `pnpm test:coverage`:
 
 #### Evidence Links
 
-- **Test Guide:** [docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md#unit-testing-with-vitest)
+- **Test Guide:** [docs/70-reference/testing-guide.md](/70-reference/testing-guide.md#unit-testing-with-vitest)
 - **PR #XX:** Stage 3.3 unit tests implementation
 - **Configuration:** `vitest.config.ts`
 

--- a/docs/60-projects/portfolio-app/06-operations.md
+++ b/docs/60-projects/portfolio-app/06-operations.md
@@ -40,13 +40,13 @@ Security incidents follow structured runbooks for deterministic response:
 
 **Runbooks:**
 
-- **[Dependency Vulnerability Response](/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)** — Detect, triage, and remediate CVEs with MTTR targets (Critical: 24h, High: 48h, Medium: 2 weeks, Low: 4 weeks)
-- **[Secrets Incident Response](/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)** — Contain and investigate suspected secret leaks; rotate credentials; prevent recurrence
+- **[Dependency Vulnerability Response](/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md)** — Detect, triage, and remediate CVEs with MTTR targets (Critical: 24h, High: 48h, Medium: 2 weeks, Low: 4 weeks)
+- **[Secrets Incident Response](/50-operations/runbooks/rbk-portfolio-secrets-incident.md)** — Contain and investigate suspected secret leaks; rotate credentials; prevent recurrence
 
 **Policies:**
 
-- **[Security Policies & Governance](/docs/40-security/security-policies.md)** — Formal policies for dependency audit, secrets management, security headers, and incident response
-- **[Risk Register](/docs/40-security/risk-register.md)** — Inventory of known risks with severity, mitigations, and acceptance status
+- **[Security Policies & Governance](/40-security/security-policies.md)** — Formal policies for dependency audit, secrets management, security headers, and incident response
+- **[Risk Register](/40-security/risk-register.md)** — Inventory of known risks with severity, mitigations, and acceptance status
 
 **MTTR Targets & Escalation:**
 
@@ -194,7 +194,7 @@ Covers:
 - Dependabot scans weekly; PRs created for all available updates
 - GitHub Security Alerts notify immediately of CVEs
 - `pnpm audit` policy enforced in CI
-- See [Dependency Vulnerability Runbook](/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md) for response procedures
+- See [Dependency Vulnerability Runbook](/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md) for response procedures
 
 **Security Headers & CSP Monitoring:**
 
@@ -278,7 +278,7 @@ Run individual commands when debugging specific issues or during active developm
 
 **Rationale:** Local validation reduces PR iteration cycles by catching failures before CI runs. The verify script provides a single-command workflow that matches CI behavior while offering better error reporting and automatic formatting fixes.
 
-See [Testing: Local validation workflow](/docs/60-projects/portfolio-app/05-testing.md#local-validation-workflow-required) for detailed documentation of both approaches.
+See [Testing: Local validation workflow](/60-projects/portfolio-app/05-testing.md#local-validation-workflow-required) for detailed documentation of both approaches.
 
 ### Dependabot automation
 

--- a/docs/60-projects/portfolio-app/feature-inventory.md
+++ b/docs/60-projects/portfolio-app/feature-inventory.md
@@ -30,16 +30,16 @@ Provide a single, reviewer-ready list of Portfolio App features and where each i
 This inventory points to the detailed feature documentation in the portfolio features catalog.
 Use these links as the canonical source for validation steps, test coverage, and evidence links.
 
-- Core pages and reviewer journey: [/docs/00-portfolio/features/01-core-pages-reviewer-journey/index.md](/docs/00-portfolio/features/01-core-pages-reviewer-journey/index.md)
-- Evidence-first content model: [/docs/00-portfolio/features/02-evidence-first-content-model/index.md](/docs/00-portfolio/features/02-evidence-first-content-model/index.md)
-- Navigation and UX polish: [/docs/00-portfolio/features/03-navigation-ux-polish/index.md](/docs/00-portfolio/features/03-navigation-ux-polish/index.md)
-- Theming and accessibility: [/docs/00-portfolio/features/04-theming-accessibility/index.md](/docs/00-portfolio/features/04-theming-accessibility/index.md)
-- SEO, metadata, and structured data: [/docs/00-portfolio/features/05-seo-metadata-structured-data/index.md](/docs/00-portfolio/features/05-seo-metadata-structured-data/index.md)
-- Security posture and hardening: [/docs/00-portfolio/features/06-security-posture-hardening/index.md](/docs/00-portfolio/features/06-security-posture-hardening/index.md)
-- Testing and quality gates: [/docs/00-portfolio/features/07-testing-quality-gates/index.md](/docs/00-portfolio/features/07-testing-quality-gates/index.md)
-- CI/CD and environment promotion: [/docs/00-portfolio/features/08-cicd-environment-promotion/index.md](/docs/00-portfolio/features/08-cicd-environment-promotion/index.md)
-- Performance and observability: [/docs/00-portfolio/features/09-performance-observability/index.md](/docs/00-portfolio/features/09-performance-observability/index.md)
-- Documentation and governance integration: [/docs/00-portfolio/features/10-docs-governance-integration/index.md](/docs/00-portfolio/features/10-docs-governance-integration/index.md)
+- Core pages and reviewer journey: [/docs/00-portfolio/features/01-core-pages-reviewer-journey/index.md](/00-portfolio/features/01-core-pages-reviewer-journey/index.md)
+- Evidence-first content model: [/docs/00-portfolio/features/02-evidence-first-content-model/index.md](/00-portfolio/features/02-evidence-first-content-model/index.md)
+- Navigation and UX polish: [/docs/00-portfolio/features/03-navigation-ux-polish/index.md](/00-portfolio/features/03-navigation-ux-polish/index.md)
+- Theming and accessibility: [/docs/00-portfolio/features/04-theming-accessibility/index.md](/00-portfolio/features/04-theming-accessibility/index.md)
+- SEO, metadata, and structured data: [/docs/00-portfolio/features/05-seo-metadata-structured-data/index.md](/00-portfolio/features/05-seo-metadata-structured-data/index.md)
+- Security posture and hardening: [/docs/00-portfolio/features/06-security-posture-hardening/index.md](/00-portfolio/features/06-security-posture-hardening/index.md)
+- Testing and quality gates: [/docs/00-portfolio/features/07-testing-quality-gates/index.md](/00-portfolio/features/07-testing-quality-gates/index.md)
+- CI/CD and environment promotion: [/docs/00-portfolio/features/08-cicd-environment-promotion/index.md](/00-portfolio/features/08-cicd-environment-promotion/index.md)
+- Performance and observability: [/docs/00-portfolio/features/09-performance-observability/index.md](/00-portfolio/features/09-performance-observability/index.md)
+- Documentation and governance integration: [/docs/00-portfolio/features/10-docs-governance-integration/index.md](/00-portfolio/features/10-docs-governance-integration/index.md)
 
 ---
 
@@ -52,8 +52,8 @@ These are explicitly documented as planned in the architecture and roadmap; keep
 
 ## References
 
-- Portfolio App dossier hub: [/docs/60-projects/portfolio-app/index.md](/docs/60-projects/portfolio-app/index.md)
-- Architecture: [/docs/60-projects/portfolio-app/02-architecture.md](/docs/60-projects/portfolio-app/02-architecture.md)
-- Security: [/docs/60-projects/portfolio-app/04-security.md](/docs/60-projects/portfolio-app/04-security.md)
-- Testing: [/docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md)
-- Operations: [/docs/60-projects/portfolio-app/06-operations.md](/docs/60-projects/portfolio-app/06-operations.md)
+- Portfolio App dossier hub: [/docs/60-projects/portfolio-app/index.md](/60-projects/portfolio-app/index.md)
+- Architecture: [/docs/60-projects/portfolio-app/02-architecture.md](/60-projects/portfolio-app/02-architecture.md)
+- Security: [/docs/60-projects/portfolio-app/04-security.md](/60-projects/portfolio-app/04-security.md)
+- Testing: [/docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md)
+- Operations: [/docs/60-projects/portfolio-app/06-operations.md](/60-projects/portfolio-app/06-operations.md)

--- a/docs/60-projects/portfolio-app/index.md
+++ b/docs/60-projects/portfolio-app/index.md
@@ -82,10 +82,10 @@ Portfolio App must link to evidence pages for each project:
 
 ## Evidence map (review-first)
 
-- ADRs: [/docs/10-architecture/adr/](/docs/10-architecture/adr/index.md)
-- Threat model: [/docs/40-security/threat-models/portfolio-app-threat-model-v2.md](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)
-- Runbooks: [/docs/50-operations/runbooks/index.md](/docs/50-operations/runbooks/index.md)
-- CI/CD governance: [/docs/30-devops-platform/ci-cd-pipeline-overview.md](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
+- ADRs: [/docs/10-architecture/adr/](/10-architecture/adr/index.md)
+- Threat model: [/docs/40-security/threat-models/portfolio-app-threat-model-v2.md](/40-security/threat-models/portfolio-app-threat-model-v2.md)
+- Runbooks: [/docs/50-operations/runbooks/index.md](/50-operations/runbooks/index.md)
+- CI/CD governance: [/docs/30-devops-platform/ci-cd-pipeline-overview.md](/30-devops-platform/ci-cd-pipeline-overview.md)
 
 ## Reviewer path
 
@@ -93,7 +93,7 @@ Portfolio App must link to evidence pages for each project:
 - Review PR discipline and branch protection/ruleset settings to confirm required checks are enforced.
 - Validate build determinism locally with `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build` (frozen lockfile).
 - Follow evidence links from the app into this dossier, ADR index, threat model, and runbooks to confirm traceability.
-- **Review the [Threat Model](/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)** to understand security assumptions and mitigations across STRIDE categories.
+- **Review the [Threat Model](/40-security/threat-models/portfolio-app-threat-model-v2.md)** to understand security assumptions and mitigations across STRIDE categories.
 
 ## Validation / Expected outcomes
 

--- a/docs/60-projects/portfolio-docs-app/03-deployment.md
+++ b/docs/60-projects/portfolio-docs-app/03-deployment.md
@@ -167,7 +167,7 @@ Both checks must pass for production promotion. This ensures:
 - Documentation builds successfully
 - No broken links or navigation errors
 
-See [ADR-0004](/docs/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md) for rationale and [Testing](./05-testing.md) for quality gate details.
+See [ADR-0004](/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md) for rationale and [Testing](./05-testing.md) for quality gate details.
 
 ### Deployment Checks flow
 

--- a/docs/60-projects/portfolio-docs-app/04-security.md
+++ b/docs/60-projects/portfolio-docs-app/04-security.md
@@ -40,8 +40,8 @@ This page documents the security posture of the Portfolio Docs App as a public-f
 
 The Portfolio Docs App follows a dedicated hardening plan that focuses on CI audit gates, host-level security headers, and publication safety controls. See the plan and ADR for the current scope and evidence checklist:
 
-- Implementation plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/docs/40-security/portfolio-docs-hardening-implementation-plan.md)
-- ADR-0019: [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
+- Implementation plan: [/docs/40-security/portfolio-docs-hardening-implementation-plan.md](/40-security/portfolio-docs-hardening-implementation-plan.md)
+- ADR-0019: [/docs/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md](/10-architecture/adr/adr-0019-portfolio-docs-hardening-baseline.md)
 
 ## Host-level security headers
 

--- a/docs/60-projects/portfolio-docs-app/05-testing.md
+++ b/docs/60-projects/portfolio-docs-app/05-testing.md
@@ -213,14 +213,14 @@ Quality gates are “working” when:
 - **Lint failure**: Run `pnpm lint:fix` to auto-fix where possible; review ESLint errors and update code to comply
 - **Typecheck failure**: Review TypeScript errors; update types or use `@ts-expect-error` with justification for edge cases
 - **Format failure**: Run `pnpm format:write` to auto-format all files; commit the changes
-- **Build failure due to broken links**: Remove premature links; use path references until the target exists; see [Broken Links Triage runbook](/docs/50-operations/runbooks/rbk-docs-broken-links-triage.md)
+- **Build failure due to broken links**: Remove premature links; use path references until the target exists; see [Broken Links Triage runbook](/50-operations/runbooks/rbk-docs-broken-links-triage.md)
 - **Lint rules become noisy**: Adjust rules carefully in `eslint.config.mjs` and document governance changes as a controlled decision (consider ADR if major change)
 - **Formatting drift**: Enforce formatting checks in CI (already configured); ensure contributors run `pnpm format:write` before committing
 
 ## References
 
-- ADR-0004: Expand CI and Deployment Quality Gates: [adr-0004-expand-ci-deploy-quality-gates.md](/docs/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md)
+- ADR-0004: Expand CI and Deployment Quality Gates: [adr-0004-expand-ci-deploy-quality-gates.md](/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md)
 - Documentation style guide (internal-only): `docs/_meta/doc-style-guide.md`
 - Contribution rules and PR checklists (repo root): `CONTRIBUTING.md` / `.github/PULL_REQUEST_TEMPLATE.md`
 - Deployment model: [03-deployment.md](./03-deployment.md)
-- Operations runbooks: [rbk-docs-deploy.md](/docs/50-operations/runbooks/rbk-docs-deploy.md)
+- Operations runbooks: [rbk-docs-deploy.md](/50-operations/runbooks/rbk-docs-deploy.md)

--- a/docs/60-projects/portfolio-docs-app/07-troubleshooting.md
+++ b/docs/60-projects/portfolio-docs-app/07-troubleshooting.md
@@ -178,15 +178,15 @@ When the site builds successfully locally but fails in production (Vercel), refe
 
 - **Symptom: Site returns 404 or pages are missing**
   - Likely cause: Output directory misconfigured
-  - See: [Output directory mismatch](/docs/50-operations/runbooks/rbk-docs-deploy.md#failure-output-directory-mismatch-404-errors-or-missing-pages)
+  - See: [Output directory mismatch](/50-operations/runbooks/rbk-docs-deploy.md#failure-output-directory-mismatch-404-errors-or-missing-pages)
 
 - **Symptom: Build fails with dependency/version errors in Vercel (but passes locally)**
   - Likely cause: pnpm lockfile drift or version mismatch
-  - See: [pnpm lockfile/version mismatch](/docs/50-operations/runbooks/rbk-docs-deploy.md#failure-pnpm-lockfile-drift-or-version-mismatch)
+  - See: [pnpm lockfile/version mismatch](/50-operations/runbooks/rbk-docs-deploy.md#failure-pnpm-lockfile-drift-or-version-mismatch)
 
 - **Symptom: Build shows no output or unclear status**
   - Likely cause: Build step ignored or webhook misconfigured
-  - See: [Missing build logs](/docs/50-operations/runbooks/rbk-docs-deploy.md#failure-missing-build-logs-or-build-doesnt-start)
+  - See: [Missing build logs](/50-operations/runbooks/rbk-docs-deploy.md#failure-missing-build-logs-or-build-doesnt-start)
 
 ## Failure modes / Troubleshooting
 

--- a/docs/70-reference/evidence-audit-checklist.md
+++ b/docs/70-reference/evidence-audit-checklist.md
@@ -38,10 +38,10 @@ Provide a repeatable, evidence-first checklist to validate claims across the Por
 
 **Evidence to verify:**
 
-- Portfolio App dossier: [/docs/60-projects/portfolio-app/index.md](/docs/60-projects/portfolio-app/index.md)
-- ADR index: [/docs/10-architecture/adr/index.md](/docs/10-architecture/adr/index.md)
-- Threat models: [/docs/40-security/threat-models/index.md](/docs/40-security/threat-models/index.md)
-- Runbooks: [/docs/50-operations/runbooks/index.md](/docs/50-operations/runbooks/index.md)
+- Portfolio App dossier: [/docs/60-projects/portfolio-app/index.md](/60-projects/portfolio-app/index.md)
+- ADR index: [/docs/10-architecture/adr/index.md](/10-architecture/adr/index.md)
+- Threat models: [/docs/40-security/threat-models/index.md](/40-security/threat-models/index.md)
+- Runbooks: [/docs/50-operations/runbooks/index.md](/50-operations/runbooks/index.md)
 
 ### 2) Testing and CI claims
 
@@ -51,9 +51,9 @@ Provide a repeatable, evidence-first checklist to validate claims across the Por
 
 **Evidence to verify:**
 
-- CI pipeline overview: [/docs/30-devops-platform/ci-cd-pipeline-overview.md](/docs/30-devops-platform/ci-cd-pipeline-overview.md)
-- Testing guide: [/docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md)
-- Portfolio App testing dossier: [/docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md)
+- CI pipeline overview: [/docs/30-devops-platform/ci-cd-pipeline-overview.md](/30-devops-platform/ci-cd-pipeline-overview.md)
+- Testing guide: [/docs/70-reference/testing-guide.md](/70-reference/testing-guide.md)
+- Portfolio App testing dossier: [/docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md)
 
 ### 3) Security and operations claims
 
@@ -63,9 +63,9 @@ Provide a repeatable, evidence-first checklist to validate claims across the Por
 
 **Evidence to verify:**
 
-- Security dossier: [/docs/60-projects/portfolio-app/04-security.md](/docs/60-projects/portfolio-app/04-security.md)
-- Threat models: [/docs/40-security/threat-models/index.md](/docs/40-security/threat-models/index.md)
-- Runbooks: [/docs/50-operations/runbooks/index.md](/docs/50-operations/runbooks/index.md)
+- Security dossier: [/docs/60-projects/portfolio-app/04-security.md](/60-projects/portfolio-app/04-security.md)
+- Threat models: [/docs/40-security/threat-models/index.md](/40-security/threat-models/index.md)
+- Runbooks: [/docs/50-operations/runbooks/index.md](/50-operations/runbooks/index.md)
 
 ### 4) Documentation integrity
 
@@ -75,9 +75,9 @@ Provide a repeatable, evidence-first checklist to validate claims across the Por
 
 **Evidence to verify:**
 
-- Roadmap: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
-- Release notes: [/docs/00-portfolio/release-notes/index.md](/docs/00-portfolio/release-notes/index.md)
-- Dossier contract: [/docs/60-projects/index.md](/docs/60-projects/index.md)
+- Roadmap: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)
+- Release notes: [/docs/00-portfolio/release-notes/index.md](/00-portfolio/release-notes/index.md)
+- Dossier contract: [/docs/60-projects/index.md](/60-projects/index.md)
 
 ## Validation / Expected outcomes
 
@@ -93,6 +93,6 @@ Provide a repeatable, evidence-first checklist to validate claims across the Por
 
 ## References
 
-- Roadmap: [/docs/00-portfolio/roadmap/index.md](/docs/00-portfolio/roadmap/index.md)
-- Testing guide: [/docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md)
+- Roadmap: [/docs/00-portfolio/roadmap/index.md](/00-portfolio/roadmap/index.md)
+- Testing guide: [/docs/70-reference/testing-guide.md](/70-reference/testing-guide.md)
 - Dossier template: [/docs/\_meta/templates/template-project-dossier/](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/docs/_meta/templates/template-project-dossier/)

--- a/docs/70-reference/mermaid-diagram-style-guide.md
+++ b/docs/70-reference/mermaid-diagram-style-guide.md
@@ -1111,6 +1111,6 @@ sequenceDiagram
 ## See Also
 
 - [Mermaid Official Documentation](https://mermaid.js.org/) — Complete syntax reference
-- [Testing Guide](/docs/70-reference/testing-guide.md) — Example testing pyramid diagram
+- [Testing Guide](/70-reference/testing-guide.md) — Example testing pyramid diagram
 - [Doc Style Guide](https://github.com/bryce-seefieldt/portfolio-docs/tree/main/docs/_meta/doc-style-guide.md) — General documentation standards
 - [Mermaid Live Editor](https://mermaid.live) — Online diagram editor and validator

--- a/docs/70-reference/performance-optimization-guide.md
+++ b/docs/70-reference/performance-optimization-guide.md
@@ -25,7 +25,7 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
 - Vercel Speed Insights (Core Web Vitals): [portfolio-app/speed-insights](https://vercel.com/bryce-seefieldts-projects/portfolio-app/speed-insights)
 - Vercel Web Analytics (traffic): [portfolio-app/analytics](https://vercel.com/bryce-seefieldts-projects/portfolio-app/analytics)
 - Vercel docs: [Speed Insights](https://vercel.com/docs/speed-insights) | [Web Analytics](https://vercel.com/docs/analytics)
-- Troubleshooting: [Performance Troubleshooting Runbook](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)
+- Troubleshooting: [Performance Troubleshooting Runbook](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md)
 
 ## Commands
 
@@ -83,7 +83,7 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
 
 ## Notes
 
-- CI enforces 10% JS growth threshold; update baseline only with explicit justification. See [Bundle Size Regression troubleshooting](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md#bundle-size-regression) if failing.
+- CI enforces 10% JS growth threshold; update baseline only with explicit justification. See [Bundle Size Regression troubleshooting](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md#bundle-size-regression) if failing.
 - Turbopack is enabled; keep `turbopack: {}` in next.config.ts to avoid webpack conflicts when analyzer plugin is present.
 - Both `@vercel/analytics` (traffic) and `@vercel/speed-insights` (performance) are installed; they serve different purposes.
 
@@ -93,7 +93,7 @@ Quick reference for performance work on the Portfolio App: how to analyze bundle
 
 1. Check Speed Insights → Real Experience Score
 2. If RES < 90 (orange/red): Click worst metric → identify problem routes/selectors
-3. Optimize identified pages/elements (see [Poor Speed Insights Scores troubleshooting](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md#poor-speed-insights-scores-res--90))
+3. Optimize identified pages/elements (see [Poor Speed Insights Scores troubleshooting](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md#poor-speed-insights-scores-res--90))
 4. Redeploy → verify RES improves
 
 **"Which pages should I optimize first?"**

--- a/docs/70-reference/portfolio-app-github-ruleset-config.md
+++ b/docs/70-reference/portfolio-app-github-ruleset-config.md
@@ -14,7 +14,7 @@ This guide configures GitHub branch protection **rulesets** to enforce:
 - Block force-push and branch deletion
 - Automatic stale review dismissal
 
-This implements the governance model described in [ADR-0008: Portfolio App CI Quality Gates](/docs/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md).
+This implements the governance model described in [ADR-0008: Portfolio App CI Quality Gates](/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md).
 
 ## Prerequisites
 
@@ -213,10 +213,10 @@ Click **"Create"** to save the ruleset.
 
 ## Related Artifacts
 
-- [ADR-0008: Portfolio App CI Quality Gates](/docs/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md)
-- [ADR-0007: Portfolio App Hosting on Vercel](/docs/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
-- [Vercel Setup Runbook](/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md)
-- [Portfolio App Deployment Dossier](/docs/60-projects/portfolio-app/03-deployment.md)
+- [ADR-0008: Portfolio App CI Quality Gates](/10-architecture/adr/adr-0008-portfolio-app-ci-quality-gates.md)
+- [ADR-0007: Portfolio App Hosting on Vercel](/10-architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks.md)
+- [Vercel Setup Runbook](/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md)
+- [Portfolio App Deployment Dossier](/60-projects/portfolio-app/03-deployment.md)
 - [GitHub Rulesets Documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
 
 ---

--- a/docs/70-reference/testing-guide.md
+++ b/docs/70-reference/testing-guide.md
@@ -801,7 +801,7 @@ await expect(page.locator('text=Evidence Artifacts')).toBeVisible();
 
 ## See Also
 
-- [Registry Schema Guide](/docs/70-reference/registry-schema-guide.md) — Field-by-field registry reference
-- [Portfolio App: Testing](/docs/60-projects/portfolio-app/05-testing.md) — Testing dossier and CI gates
+- [Registry Schema Guide](/70-reference/registry-schema-guide.md) — Field-by-field registry reference
+- [Portfolio App: Testing](/60-projects/portfolio-app/05-testing.md) — Testing dossier and CI gates
 - [Vitest Documentation](https://vitest.dev) — Official Vitest docs
 - [Playwright Documentation](https://playwright.dev) — Official Playwright docs

--- a/docs/_archive/closed-issues/stage-3-2-app-issue.md
+++ b/docs/_archive/closed-issues/stage-3-2-app-issue.md
@@ -9,7 +9,7 @@ tags: [portfolio, roadmap, planning, phase-3, stage-3.2, app, implementation]
 **Type:** Feature / Implementation  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.2  
-**Linked Issue:** [stage-3-2-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-docs-issue.md)  
+**Linked Issue:** [stage-3-2-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-2-docs-issue.md)  
 **Duration Estimate:** 3–4 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-21  
@@ -424,9 +424,9 @@ Break the work into concrete, sequential phases with clear deliverables.
 
 ## Related Issues
 
-- **Linked:** [stage-3-2-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-docs-issue.md) (companion documentation work)
+- **Linked:** [stage-3-2-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-2-docs-issue.md) (companion documentation work)
 - **Dependency:** stage-3-1-APP-ISSUE.md (completed) — registry must exist for this to consume
-- **Reference:** Phase 3 Implementation Guide: [docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)
+- **Reference:** Phase 3 Implementation Guide: [docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md)
 
 ---
 
@@ -488,7 +488,7 @@ After Stage 3.2 is complete:
   - Evidence: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build` all pass
   - Security: "No secrets added"
   - Closes: #[issue-number] (this issue)
-  - Reference companion: [stage-3-2-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-docs-issue.md)
+  - Reference companion: [stage-3-2-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-2-docs-issue.md)
 
 - **Merge:** Requires both CI checks to pass (`ci / quality`, `ci / build`)
 - **Post-merge:** Vercel auto-deploys preview and production
@@ -497,7 +497,7 @@ After Stage 3.2 is complete:
 
 ## Reference Documentation
 
-- **Phase 3 Implementation Guide:** [phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-32-evidenceblock-component--badges-34-hours)
+- **Phase 3 Implementation Guide:** [phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-32-evidenceblock-component--badges-34-hours)
 - **Portfolio App Copilot Instructions:** Section 8 — Phase 3 Stage 3.2
 - **Component Styling Reference:** Existing components (GoldStandardBadge.tsx, Section.tsx, Callout.tsx)
 - **Registry Reference:** src/lib/registry.ts (Project type, evidenceLinks helper)

--- a/docs/_archive/closed-issues/stage-3-2-docs-issue.md
+++ b/docs/_archive/closed-issues/stage-3-2-docs-issue.md
@@ -9,7 +9,7 @@ tags: [portfolio, roadmap, planning, phase-3, stage-3.2, docs, documentation]
 **Type:** Documentation / Reference  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.2  
-**Linked Issue:** [stage-3-2-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)  
+**Linked Issue:** [stage-3-2-app-issue.md](/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)  
 **Duration Estimate:** 2–3 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-21  
@@ -19,7 +19,7 @@ tags: [portfolio, roadmap, planning, phase-3, stage-3.2, docs, documentation]
 
 ## Overview
 
-This stage complements the app implementation ([stage-3-2-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)) by updating portfolio-docs with architecture explanations, ensuring evidence consistency, and documenting the component-driven evidence visualization approach.
+This stage complements the app implementation ([stage-3-2-app-issue.md](/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)) by updating portfolio-docs with architecture explanations, ensuring evidence consistency, and documenting the component-driven evidence visualization approach.
 
 While the app work creates three reusable React components (`EvidenceBlock`, `VerificationBadge`, `BadgeGroup`), this docs work ensures reviewers understand:
 
@@ -113,7 +113,7 @@ The Portfolio App introduces a reusable component library for standardized evide
 
 Together, these components embed evidence verification into the user experience, making "show your work" a visual, interactive expectation rather than a hidden link hunt.
 
-See [Architecture — Evidence Visualization Layer](/docs/60-projects/portfolio-app/02-architecture.md#evidence-visualization-layer-stage-32) for full details.
+See [Architecture — Evidence Visualization Layer](/60-projects/portfolio-app/02-architecture.md#evidence-visualization-layer-stage-32) for full details.
 ```
 
 #### 2. Comprehensive Update to `02-architecture.md`
@@ -245,9 +245,9 @@ Evidence data flow:
 #### See Also
 
 - **Component Specifications:** Portfolio App Copilot Instructions, Section 8 — [Phase 3 Stage 3.2](https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/copilot-instructions.md#8-phase-3-stage-32--evidenceblock-components)
-- **Implementation Details:** [stage-3-2-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)
-- **Registry Schema:** [docs/70-reference/registry-schema-guide.md](/docs/70-reference/registry-schema-guide.md)
-- **Gold Standard:** [ADR-0010 — Gold Standard Exemplar](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
+- **Implementation Details:** [stage-3-2-app-issue.md](/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)
+- **Registry Schema:** [docs/70-reference/registry-schema-guide.md](/70-reference/registry-schema-guide.md)
+- **Gold Standard:** [ADR-0010 — Gold Standard Exemplar](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
 
 ```
 
@@ -341,9 +341,9 @@ However, if reviewers ask:
 
 ## Related Issues
 
-- **Linked:** [stage-3-2-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-app-issue.md) (companion implementation)
+- **Linked:** [stage-3-2-app-issue.md](/00-portfolio/roadmap/issues/stage-3-2-app-issue.md) (companion implementation)
 - **Dependency:** stage-3-1-docs-issue.md (completed) — registry documentation published
-- **Reference:** Phase 3 Implementation Guide: [docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-32-evidenceblock-component--badges-34-hours)
+- **Reference:** Phase 3 Implementation Guide: [docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-32-evidenceblock-component--badges-34-hours)
 - **Related ADR:** ADR-0010 — Gold Standard Exemplar
 
 ---
@@ -397,7 +397,7 @@ This docs work is **intentionally limited** to dossier updates and verification.
 The components themselves are NOT documented in portfolio-docs (that would be redundant). Instead:
 - Architecture page explains **why** components exist and **how** they're designed
 - Copilot instructions in portfolio-app contain **full specs** (props, styling, behavior)
-- GitHub issue ([stage-3-2-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)) contains **implementation tasks**
+- GitHub issue ([stage-3-2-app-issue.md](/00-portfolio/roadmap/issues/stage-3-2-app-issue.md)) contains **implementation tasks**
 
 This keeps implementation details close to code and architecture explanations close to decision rationale.
 
@@ -409,10 +409,10 @@ Key invariant: All evidence paths mentioned in dossier must match registry struc
 
 ## Reference Documentation
 
-- **Phase 3 Implementation Guide:** [phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-32-evidenceblock-component--badges-34-hours)
-- **Portfolio App Dossier — Architecture:** [docs/60-projects/portfolio-app/02-architecture.md](/docs/60-projects/portfolio-app/02-architecture.md)
-- **Registry Schema Guide:** [docs/70-reference/registry-schema-guide.md](/docs/70-reference/registry-schema-guide.md)
-- **ADR-0010 — Gold Standard Exemplar:** [docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar](/docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
+- **Phase 3 Implementation Guide:** [phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-32-evidenceblock-component--badges-34-hours)
+- **Portfolio App Dossier — Architecture:** [docs/60-projects/portfolio-app/02-architecture.md](/60-projects/portfolio-app/02-architecture.md)
+- **Registry Schema Guide:** [docs/70-reference/registry-schema-guide.md](/70-reference/registry-schema-guide.md)
+- **ADR-0010 — Gold Standard Exemplar:** [docs/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar](/10-architecture/adr/adr-0010-portfolio-app-as-gold-standard-exemplar.md)
 - **Copilot Instructions (Portfolio App):** Section 8 — Phase 3 Stage 3.2
 
 ```

--- a/docs/_archive/closed-issues/stage-3-3-app-issue.md
+++ b/docs/_archive/closed-issues/stage-3-3-app-issue.md
@@ -20,7 +20,7 @@ tags:
 **Type:** Testing / Quality Assurance  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.3  
-**Linked Issue:** [stage-3-3-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-3-docs-issue.md)  
+**Linked Issue:** [stage-3-3-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-3-docs-issue.md)  
 **Duration Estimate:** 4–6 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-22  

--- a/docs/_archive/closed-issues/stage-3-3-docs-issue.md
+++ b/docs/_archive/closed-issues/stage-3-3-docs-issue.md
@@ -19,7 +19,7 @@ tags:
 **Type:** Documentation / Reference  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.3  
-**Linked Issue:** [stage-3-3-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-3-app-issue.md)  
+**Linked Issue:** [stage-3-3-app-issue.md](/00-portfolio/roadmap/issues/stage-3-3-app-issue.md)  
 **Duration Estimate:** 2–3 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-22  
@@ -29,7 +29,7 @@ tags:
 
 ## Overview
 
-This stage complements the app testing implementation ([stage-3-3-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-3-app-issue.md)) by documenting the testing strategy, updating the Portfolio App dossier with testing architecture, and providing reference guides for writing tests.
+This stage complements the app testing implementation ([stage-3-3-app-issue.md](/00-portfolio/roadmap/issues/stage-3-3-app-issue.md)) by documenting the testing strategy, updating the Portfolio App dossier with testing architecture, and providing reference guides for writing tests.
 
 While the app work creates unit tests (Vitest) and E2E tests (Playwright) for registry validation and evidence link resolution, this docs work ensures reviewers understand:
 
@@ -326,9 +326,9 @@ Tests run in GitHub Actions before build:
 
 #### See Also
 
-- **Testing Guide:** [docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md)
-- **Testing Dossier:** [docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md)
-- **Implementation:** [stage-3-3-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-3-app-issue.md)
+- **Testing Guide:** [docs/70-reference/testing-guide.md](/70-reference/testing-guide.md)
+- **Testing Dossier:** [docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md)
+- **Implementation:** [stage-3-3-app-issue.md](/00-portfolio/roadmap/issues/stage-3-3-app-issue.md)
 
 ````
 
@@ -596,13 +596,13 @@ test.describe('Feature Name', () => {
 
 **Links to:**
 
-- Testing Guide: [docs/70-reference/testing-guide.md](/docs/70-reference/testing-guide.md)
-- Testing Dossier: [docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md)
-- CI/CD Pipeline: [docs/devops-platform/ci-cd-pipeline-overview.md](/docs/devops-platform/ci-cd-pipeline-overview)
+- Testing Guide: [docs/70-reference/testing-guide.md](/70-reference/testing-guide.md)
+- Testing Dossier: [docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md)
+- CI/CD Pipeline: [docs/devops-platform/ci-cd-pipeline-overview.md](/devops-platform/ci-cd-pipeline-overview)
 
 **Referenced by:**
 
-- Architecture page: [docs/60-projects/portfolio-app/02-architecture.md](/docs/60-projects/portfolio-app/02-architecture.md)
+- Architecture page: [docs/60-projects/portfolio-app/02-architecture.md](/60-projects/portfolio-app/02-architecture.md)
 - Copilot instructions: `.github/copilot-instructions.md`
 
 **Update required in:**
@@ -761,9 +761,9 @@ All updates must follow portfolio-docs authoring standards:
 
 ## Related Issues
 
-- **Linked:** [stage-3-3-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-3-app-issue.md) (companion implementation)
+- **Linked:** [stage-3-3-app-issue.md](/00-portfolio/roadmap/issues/stage-3-3-app-issue.md) (companion implementation)
 - **Dependency:** stage-3-2-docs-issue.md (completed) — evidence components documented
-- **Reference:** Phase 3 Implementation Guide: [docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-33-unit--e2e-tests-46-hours)
+- **Reference:** Phase 3 Implementation Guide: [docs/00-portfolio/roadmap/phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-33-unit--e2e-tests-46-hours)
 
 ---
 
@@ -790,14 +790,14 @@ It does NOT replace official Vitest/Playwright documentation. Engineers should r
 
 **Evidence Consistency:**
 
-All testing documentation references the actual test files created in [stage-3-3-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-3-app-issue.md). No fictional examples.
+All testing documentation references the actual test files created in [stage-3-3-app-issue.md](/00-portfolio/roadmap/issues/stage-3-3-app-issue.md). No fictional examples.
 
 ---
 
 ## Reference Documentation
 
-- **Phase 3 Implementation Guide:** [phase-3-implementation-guide.md](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-33-unit--e2e-tests-46-hours)
-- **Portfolio App Dossier — Testing:** [docs/60-projects/portfolio-app/05-testing.md](/docs/60-projects/portfolio-app/05-testing.md)
-- **CI/CD Pipeline:** [docs/devops-platform/ci-cd-pipeline-overview.md](/docs/devops-platform/ci-cd-pipeline-overview)
+- **Phase 3 Implementation Guide:** [phase-3-implementation-guide.md](/00-portfolio/roadmap/phase-3-implementation-guide.md#stage-33-unit--e2e-tests-46-hours)
+- **Portfolio App Dossier — Testing:** [docs/60-projects/portfolio-app/05-testing.md](/60-projects/portfolio-app/05-testing.md)
+- **CI/CD Pipeline:** [docs/devops-platform/ci-cd-pipeline-overview.md](/devops-platform/ci-cd-pipeline-overview)
 - **Vitest Documentation:** https://vitest.dev
 - **Playwright Documentation:** https://playwright.dev

--- a/docs/_archive/closed-issues/stage-3-4-app-issue.md
+++ b/docs/_archive/closed-issues/stage-3-4-app-issue.md
@@ -10,7 +10,7 @@ tags:
 **Type:** Documentation / Configuration Update  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.4  
-**Linked Issue:** [stage-3-4-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-4-docs-issue.md)  
+**Linked Issue:** [stage-3-4-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-4-docs-issue.md)  
 **Duration Estimate:** 1–2 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-22  
@@ -175,7 +175,7 @@ This stage is complete when:
 This stage depends on:
 
 - **portfolio-docs Stage 3.4 issue completion:** ADR-0011 and ADR-0012 must be published in docs before this app issue can add accurate links
-- **Companion issue:** [stage-3-4-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-4-docs-issue.md)
+- **Companion issue:** [stage-3-4-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-4-docs-issue.md)
 
 **Merge order:** Docs PRs must merge to `main` first; then app issue can reference published URLs and create its PR.
 
@@ -207,8 +207,8 @@ This stage is complete and ready to merge when:
 
 ## Related Issues & Links
 
-- **Companion docs issue:** [Stage 3.4: ADRs & Documentation — Documentation](/docs/00-portfolio/roadmap/issues/stage-3-4-docs-issue.md)
-- **Parent phase:** [Phase 3 Implementation Guide](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)
+- **Companion docs issue:** [Stage 3.4: ADRs & Documentation — Documentation](/00-portfolio/roadmap/issues/stage-3-4-docs-issue.md)
+- **Parent phase:** [Phase 3 Implementation Guide](/00-portfolio/roadmap/phase-3-implementation-guide.md)
 - **Related ADRs (being created in docs issue):**
   - ADR-0011: Data-Driven Project Registry
   - ADR-0012: Cross-Repo Documentation Linking

--- a/docs/_archive/closed-issues/stage-3-4-docs-issue.md
+++ b/docs/_archive/closed-issues/stage-3-4-docs-issue.md
@@ -10,7 +10,7 @@ tags:
 **Type:** Documentation / ADR / Reference  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.4  
-**Linked Issue:** [stage-3-4-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-4-app-issue.md)  
+**Linked Issue:** [stage-3-4-app-issue.md](/00-portfolio/roadmap/issues/stage-3-4-app-issue.md)  
 **Duration Estimate:** 3–4 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-22  
@@ -162,8 +162,8 @@ tags: [adr, architecture, phase-3, registry, data-driven]
 
 #### Section 6: Implementation
 
-- Implementation guide: [Phase 3 Implementation Guide](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)
-- Schema reference: [Registry Schema Guide](/docs/70-reference/registry-schema-guide.md)
+- Implementation guide: [Phase 3 Implementation Guide](/00-portfolio/roadmap/phase-3-implementation-guide.md)
+- Schema reference: [Registry Schema Guide](/70-reference/registry-schema-guide.md)
 - Related components: EvidenceBlock, VerificationBadge (Stage 3.2)
 
 ---
@@ -466,8 +466,8 @@ This stage is complete and ready to deploy when:
 
 ## References & Related Issues
 
-- **Companion app issue:** [Stage 3.4: ADRs & Documentation — App Implementation](/docs/00-portfolio/roadmap/issues/stage-3-4-app-issue.md)
-- **Parent guide:** [Phase 3 Implementation Guide](/docs/00-portfolio/roadmap/phase-3-implementation-guide.md)
+- **Companion app issue:** [Stage 3.4: ADRs & Documentation — App Implementation](/00-portfolio/roadmap/issues/stage-3-4-app-issue.md)
+- **Parent guide:** [Phase 3 Implementation Guide](/00-portfolio/roadmap/phase-3-implementation-guide.md)
 - **Predecessor stages:**
   - Stage 3.1: Data-Driven Registry (complete)
   - Stage 3.2: Evidence Components (complete)

--- a/docs/_archive/closed-issues/stage-3-5-app-issue.md
+++ b/docs/_archive/closed-issues/stage-3-5-app-issue.md
@@ -9,7 +9,7 @@ tags: [portfolio, roadmap, planning, phase-3, stage-3.5, app, ci, validation]
 **Type:** Feature / CI Enhancement  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.5  
-**Linked Issue:** [stage-3-5-docs-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-5-docs-issue.md)  
+**Linked Issue:** [stage-3-5-docs-issue.md](/00-portfolio/roadmap/issues/stage-3-5-docs-issue.md)  
 **Duration Estimate:** 2–3 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-23  

--- a/docs/_archive/closed-issues/stage-3-5-docs-issue.md
+++ b/docs/_archive/closed-issues/stage-3-5-docs-issue.md
@@ -10,7 +10,7 @@ tags:
 **Type:** Documentation / Runbook / Troubleshooting  
 **Phase:** Phase 3 — Scaling & Governance  
 **Stage:** 3.5  
-**Linked Issue:** [stage-3-5-app-issue.md](/docs/00-portfolio/roadmap/issues/stage-3-5-app-issue.md)  
+**Linked Issue:** [stage-3-5-app-issue.md](/00-portfolio/roadmap/issues/stage-3-5-app-issue.md)  
 **Duration Estimate:** 2–3 hours  
 **Assignee:** GitHub Copilot / Engineering Lead  
 **Created:** 2026-01-23  

--- a/docs/_archive/closed-issues/stage-4-2-app-issue.md
+++ b/docs/_archive/closed-issues/stage-4-2-app-issue.md
@@ -510,7 +510,7 @@ Core Web Vitals Targets:
 
 ## Related Documentation
 
-- [Phase 4 Implementation Guide](/docs/00-portfolio/roadmap/phase-4-implementation-guide.md) — Stage 4.2 section
+- [Phase 4 Implementation Guide](/00-portfolio/roadmap/phase-4-implementation-guide.md) — Stage 4.2 section
 - [ADR-0013: Multi-Environment Deployment](docs/10-architecture/adr/adr-0013-multi-environment-deployment.md) — Environment context for performance testing
 - [Stage 4.2 Docs Issue](stage-4-2-docs-issue.md) — Companion documentation deliverables
 

--- a/docs/_archive/closed-issues/stage-4-3-docs-issue.md
+++ b/docs/_archive/closed-issues/stage-4-3-docs-issue.md
@@ -672,23 +672,23 @@ tags: [operations, runbooks, procedures, incident-response]
 
 **Deployment Runbooks**
 
-- [Deployment Failure Recovery](/docs/50-operations/runbooks/rbk-portfolio-deployment-failure.md) — Detect and rollback failed deployments (MTTR: 5 min)
+- [Deployment Failure Recovery](/50-operations/runbooks/rbk-portfolio-deployment-failure.md) — Detect and rollback failed deployments (MTTR: 5 min)
 - Redeployment Procedures -`/docs/50-operations/runbooks/rbk-portfolio-redeployment.md` — Manual deployment commands and verification (future)
 
 **Incident Response Runbooks**
 
-- [General Incident Response Framework](/docs/50-operations/runbooks/rbk-portfolio-incident-response.md) — Framework for all incidents (severity levels, triage, postmortem)
-- [Service Degradation](/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md) — Diagnose and resolve performance/availability issues (MTTR: 10 min)
+- [General Incident Response Framework](/50-operations/runbooks/rbk-portfolio-incident-response.md) — Framework for all incidents (severity levels, triage, postmortem)
+- [Service Degradation](/50-operations/runbooks/rbk-portfolio-service-degradation.md) — Diagnose and resolve performance/availability issues (MTTR: 10 min)
 - Security Incident Response - `/docs/50-operations/runbooks/rbk-portfolio-security-incident.md` — Detect and respond to security issues (future)
 
 **Performance & Optimization Runbooks**
 
-- [Performance Optimization](/docs/50-operations/runbooks/rbk-portfolio-performance-optimization.md) — Proactive performance tuning and optimization
-- [Performance Troubleshooting](/docs/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md) — Diagnose and fix performance problems
+- [Performance Optimization](/50-operations/runbooks/rbk-portfolio-performance-optimization.md) — Proactive performance tuning and optimization
+- [Performance Troubleshooting](/50-operations/runbooks/rbk-portfolio-performance-troubleshooting.md) — Diagnose and fix performance problems
 
 **Operational Readiness**
 
-- [Observability & Monitoring](/docs/30-devops-platform/observability-health-checks.md) — Health checks, logging, monitoring architecture
+- [Observability & Monitoring](/30-devops-platform/observability-health-checks.md) — Health checks, logging, monitoring architecture
 
 #### Section 3: Quick Reference (Severity-Based)
 

--- a/docs/_meta/env/portfolio-docs-env-contract.md
+++ b/docs/_meta/env/portfolio-docs-env-contract.md
@@ -247,7 +247,7 @@ grep -r "localhost:3000" build/  # Should appear if DOCUSAURUS_SITE_URL is local
 - Repository root: `.env.example` (canonical contract)
 - Docusaurus config: `docusaurus.config.ts` (implementation)
 - Docusaurus docs: [Using Environment Variables](https://docusaurus.io/docs/deployment#using-environment-variables)
-- Portfolio App env contract: [portfolio-app-env-contract.md](/docs/_meta/env/portfolio-app-env-contract.md)
+- Portfolio App env contract: [portfolio-app-env-contract.md](/_meta/env/portfolio-app-env-contract.md)
 
 ---
 

--- a/docs/_meta/templates/README.md
+++ b/docs/_meta/templates/README.md
@@ -646,13 +646,13 @@ A Phase Implementation Guide is complete when:
 
 See existing examples:
 
-- [Phase 2 Implementation Guide](/docs/00-portfolio/phase-2-implementation-guide.md) — Sequential steps approach
-- [Phase 3 Implementation Guide](/docs/00-portfolio/phase-3-implementation-guide.md) — Modular stages approach
+- [Phase 2 Implementation Guide](/00-portfolio/phase-2-implementation-guide.md) — Sequential steps approach
+- [Phase 3 Implementation Guide](/00-portfolio/phase-3-implementation-guide.md) — Modular stages approach
 
 See existing examples:
 
-- [Phase 2 Implementation Guide](/docs/00-portfolio/phase-2-implementation-guide.md) — Sequential steps approach
-- [Phase 3 Implementation Guide](/docs/00-portfolio/phase-3-implementation-guide.md) — Modular stages approach
+- [Phase 2 Implementation Guide](/00-portfolio/phase-2-implementation-guide.md) — Sequential steps approach
+- [Phase 3 Implementation Guide](/00-portfolio/phase-3-implementation-guide.md) — Modular stages approach
 
 Both follow this template structure and serve as reference implementations.
 
@@ -801,11 +801,11 @@ Before marking the issue done:
 
 **App Implementation Example:**
 
-See [roadmap issues index](/docs/00-portfolio/roadmap/issues/) for active and completed stage issue records.
+See [roadmap issues index](/00-portfolio/roadmap/issues/) for active and completed stage issue records.
 
 **Documentation Example:**
 
-See [Phase 3 Implementation Guide](/docs/00-portfolio/roadmap/phase-3-implementation-guide/) for a full paired app/docs stage planning example.
+See [Phase 3 Implementation Guide](/00-portfolio/roadmap/phase-3-implementation-guide/) for a full paired app/docs stage planning example.
 
 ### Policy Consistency Requirements
 

--- a/docs/_meta/templates/template-phase-implementation-guide.md
+++ b/docs/_meta/templates/template-phase-implementation-guide.md
@@ -386,10 +386,10 @@ pnpm start                      # Local dev server
 ## Reference Documentation
 
 - [Roadmap — Phase [X]]([link])
-- [Architecture Decision Records (ADRs)](/docs/10-architecture/adr/index.md)
-- [Project Dossier Template](/docs/_meta/templates/template-project-dossier/)
-- [Runbook Template](/docs/_meta/templates/template-runbook.md)
-- [Threat Model Template](/docs/_meta/templates/template-threat-model.md)
+- [Architecture Decision Records (ADRs)](/10-architecture/adr/index.md)
+- [Project Dossier Template](/_meta/templates/template-project-dossier/)
+- [Runbook Template](/_meta/templates/template-runbook.md)
+- [Threat Model Template](/_meta/templates/template-threat-model.md)
 
 ---
 

--- a/docs/_meta/templates/template-project-dossier/03-deployment.md
+++ b/docs/_meta/templates/template-project-dossier/03-deployment.md
@@ -107,7 +107,7 @@ Both checks must pass for production promotion. This ensures:
 - Documentation builds successfully
 - No broken links or navigation errors
 
-See [ADR-0004](/docs/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md) for rationale and [Testing](./05-testing.md) for quality gate details.
+See [ADR-0004](/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md) for rationale and [Testing](./05-testing.md) for quality gate details.
 
 ### Deployment Checks flow
 

--- a/docs/_meta/templates/template-project-dossier/05-testing.md
+++ b/docs/_meta/templates/template-project-dossier/05-testing.md
@@ -149,14 +149,14 @@ Quality gates are “working” when:
 - **Lint failure**: Run `pnpm lint:fix` to auto-fix where possible; review ESLint errors and update code to comply
 - **Typecheck failure**: Review TypeScript errors; update types or use `@ts-expect-error` with justification for edge cases
 - **Format failure**: Run `pnpm format:write` to auto-format all files; commit the changes
-- **Build failure due to broken links**: Remove premature links; use path references until the target exists; see [Broken Links Triage runbook](/docs/50-operations/runbooks/rbk-docs-broken-links-triage.md)
+- **Build failure due to broken links**: Remove premature links; use path references until the target exists; see [Broken Links Triage runbook](/50-operations/runbooks/rbk-docs-broken-links-triage.md)
 - **Lint rules become noisy**: Adjust rules carefully in `eslint.config.mjs` and document governance changes as a controlled decision (consider ADR if major change)
 - **Formatting drift**: Enforce formatting checks in CI (already configured); ensure contributors run `pnpm format:write` before committing
 
 ## References
 
-- ADR-0004: Expand CI and Deployment Quality Gates: [adr-0004-expand-ci-deploy-quality-gates.md](/docs/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md)
+- ADR-0004: Expand CI and Deployment Quality Gates: [adr-0004-expand-ci-deploy-quality-gates.md](/10-architecture/adr/adr-0004-expand-ci-deploy-quality-gates.md)
 - Documentation style guide (internal-only): `docs/_meta/doc-style-guide.md`
 - Contribution rules and PR checklists (repo root): `CONTRIBUTING.md` / `.github/PULL_REQUEST_TEMPLATE.md`
 - Deployment model: [03-deployment.md](./03-deployment.md)
-- Operations runbooks: [rbk-docs-deploy.md](/docs/50-operations/runbooks/rbk-docs-deploy.md)
+- Operations runbooks: [rbk-docs-deploy.md](/50-operations/runbooks/rbk-docs-deploy.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,28 +42,28 @@ This is not “notes.” It is a living, version-controlled evidence system.
 
 ## Start here (fast reviewer path)
 
-1. [Reviewer guide](/docs/00-portfolio/reviewer-guide.md)
-2. [Portfolio App Development Roadmap](/docs/00-portfolio/roadmap/index.md)
-3. [Portfolio App Project Dossier](/docs/60-projects/portfolio-app/index.md)
+1. [Reviewer guide](/00-portfolio/reviewer-guide.md)
+2. [Portfolio App Development Roadmap](/00-portfolio/roadmap/index.md)
+3. [Portfolio App Project Dossier](/60-projects/portfolio-app/index.md)
 4. Application evidence validation:
 
-- [ADRs](/docs/10-architecture/adr/index.md)
-- [Threat Models](/docs/40-security/threat-models/index.md)
-- [Runbooks](/docs/50-operations/runbooks/index.md)
-- [Evidence checklist](/docs/70-reference/evidence-audit-checklist.md)
+- [ADRs](/10-architecture/adr/index.md)
+- [Threat Models](/40-security/threat-models/index.md)
+- [Runbooks](/50-operations/runbooks/index.md)
+- [Evidence checklist](/70-reference/evidence-audit-checklist.md)
 
 ## How this repository is organized
 
 Top-level domains (each has its own `index.md` and governance):
 
-- [`00-portfolio/`](/docs/00-portfolio/index.md) — curated portfolio narrative (capabilities, roadmap, release notes)
-- [`10-architecture/`](/docs/10-architecture/index.md) — system design, C4 views, ADRs, integrations, data flows
-- [`20-engineering/`](/docs/20-engineering/index.md) — standards, local dev, testing strategy, dependency management
-- [`30-devops-platform/`](/docs/30-devops-platform/index.md) — CI/CD, environments, infra, observability, rollback strategy
-- [`40-security/`](/docs/40-security/index.md) — security posture, threat models, secure SDLC controls, evidence
-- [`50-operations/`](/docs/50-operations/index.md) — runbooks, incident response, DR/BCP, service management
-- [`60-projects/`](/docs/60-projects/index.md) — per-project dossiers (portfolio app + demos)
-- [`70-reference/`](/docs/70-reference/index.md) — CLI/config references and quick operational diagnostics
+- [`00-portfolio/`](/00-portfolio/index.md) — curated portfolio narrative (capabilities, roadmap, release notes)
+- [`10-architecture/`](/10-architecture/index.md) — system design, C4 views, ADRs, integrations, data flows
+- [`20-engineering/`](/20-engineering/index.md) — standards, local dev, testing strategy, dependency management
+- [`30-devops-platform/`](/30-devops-platform/index.md) — CI/CD, environments, infra, observability, rollback strategy
+- [`40-security/`](/40-security/index.md) — security posture, threat models, secure SDLC controls, evidence
+- [`50-operations/`](/50-operations/index.md) — runbooks, incident response, DR/BCP, service management
+- [`60-projects/`](/60-projects/index.md) — per-project dossiers (portfolio app + demos)
+- [`70-reference/`](/70-reference/index.md) — CLI/config references and quick operational diagnostics
 
 ## Documentation governance model
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -158,7 +158,7 @@ const config: Config = {
           items: [
             {
               label: 'Portfolio Documentation',
-              to: '/docs',
+              to: '/',
             },
           ],
         },


### PR DESCRIPTION
## Problem

After migrating Docusaurus to baseUrl=/docs/ with routeBasePath='/', many markdown links still used hardcoded /docs/... paths. Docusaurus resolves those as double-prefixed routes and fails build-time broken-link checks in Vercel.

## Fix

- Normalize internal markdown links from /docs/... to /...
- Normalize docs-home links from /docs to /
- Update footer docs link in docusaurus.config.ts from /docs to /

## Validation

- pnpm build passes locally on this branch
- Vercel failure root cause confirmed via inspect logs (broken links to /docs from many pages)

## Notes

This is a mechanical path-prefix normalization only; no content semantics changed.
