### PR TITLE
fix: route /docs baseUrl correctly on portfolio-docs Vercel origin

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,21 @@
 {
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/docs/",
+      "permanent": false
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/docs",
+      "destination": "/"
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "/:path*"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Problem

After setting Docusaurus `baseUrl=/docs/`, Vercel docs-origin requests showed:
- root (`/`) loads HTML but triggers Docusaurus baseUrl banner
- `/docs/` and `/docs/*` return 404

This breaks both direct docs-origin preview usage and upstream proxying behavior.

## Fix

Update `vercel.json` with:
- redirect `/` -> `/docs/`
- rewrite `/docs` -> `/`
- rewrite `/docs/:path*` -> `/:path*`

This keeps canonical/public URLs under `/docs/*` while mapping to static build output generated at root.

## Validation

- `pnpm build` passes locally.

