### PR TITLE
docs: canonicalize production URLs to bryce.seefieldt.ca/docs

### DIFF
--- a/.copilot/session-context.md
+++ b/.copilot/session-context.md
@@ -173,7 +173,7 @@ All work in both repositories **MUST** use templates for proper governance and t
 **Portfolio-docs authoring (this repository):**
 
 - Hosted docs pages: use relative links starting with `/docs/`, include section prefix numbers (e.g., `00-portfolio`), and include `.md` extensions. Example: `/docs/10-architecture/adr/adr-0001-adopt-docusaurus-for-portfolio-docs.md`.
-- Docs hub pages (`index.md`): when constructing published URLs, omit `index.md` (e.g., `docs/00-portfolio/index.md` → `https://bns-portfolio-docs.vercel.app/docs/portfolio/`, built with `NEXT_PUBLIC_DOCS_BASE_URL + "docs/portfolio/"`).
+- Docs hub pages (`index.md`): when constructing published URLs, omit `index.md` (e.g., `docs/00-portfolio/index.md` → `https://bryce.seefieldt.ca/docs/portfolio/`, built with `NEXT_PUBLIC_DOCS_BASE_URL + "docs/portfolio/"`). Preview version: `https://bns-portfolio-docs.vercel.app/docs/portfolio/`.
 - Non-hosted files (including anything under `docs/_meta`): link via GitHub blob URLs using repo/env variables (`https://github.com/${DOCUSAURUS_GITHUB_ORG}/${DOCUSAURUS_GITHUB_REPO_DOCS}/blob/main/<path>`). This rule also applies when portfolio-app links to `docs/_meta` content.
 - Env-first rule: For any deployed URLs (docs or app), build URLs from environment variables (`DOCUSAURUS_SITE_URL` + `DOCUSAURUS_BASE_URL`, `NEXT_PUBLIC_DOCS_BASE_URL`, `NEXT_PUBLIC_DOCS_GITHUB_URL`). Do **not** hardcode production hosts. The only exception is internal `/docs/...` links inside authored content, which stay relative as above.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -151,8 +151,8 @@ This is analogous to Next.js `NEXT_PUBLIC_*` convention.
 
 - **Purpose**: Base URL of the deployed site (SEO, sitemap, canonical URLs)
 - **Local**: `http://localhost:3000`
-- **Production**: `https://bns-portfolio-docs.vercel.app`
-- **Default**: `https://bns-portfolio-docs.vercel.app` (fallback if not set)
+- **Production**: `https://bryce.seefieldt.ca/docs` (canonical domain; preview: `https://bns-portfolio-docs.vercel.app`)
+- **Default**: `https://bryce.seefieldt.ca/docs` (fallback if not set)
 
 #### `DOCUSAURUS_BASE_URL`
 
@@ -170,7 +170,7 @@ This is analogous to Next.js `NEXT_PUBLIC_*` convention.
 
 - **Purpose**: URL of the Portfolio App for cross-linking from docs to live app
 - **Local**: `http://localhost:3000`
-- **Production**: `https://bns-portfolio-app.vercel.app`
+- **Production**: `https://bryce.seefieldt.ca` (canonical domain; preview: `https://bns-portfolio.vercel.app`)
 
 ### File Structure
 
@@ -196,12 +196,12 @@ DOCUSAURUS_GITHUB_REPO_APP=portfolio-app
 Set environment variables in Vercel Dashboard under **Settings → Environment Variables**:
 
 ```
-DOCUSAURUS_SITE_URL=https://bns-portfolio-docs.vercel.app
-DOCUSAURUS_BASE_URL=/
+DOCUSAURUS_SITE_URL=https://bryce.seefieldt.ca/docs
+DOCUSAURUS_BASE_URL=/docs/
 DOCUSAURUS_GITHUB_ORG=bryce-seefieldt
 DOCUSAURUS_GITHUB_REPO_DOCS=portfolio-docs
 DOCUSAURUS_GITHUB_REPO_APP=portfolio-app
-DOCUSAURUS_PORTFOLIO_APP_URL=https://bns-portfolio-app.vercel.app
+DOCUSAURUS_PORTFOLIO_APP_URL=https://bryce.seefieldt.ca
 ```
 
 ### Full Documentation

--- a/docs/30-devops-platform/ci-cd-pipeline-overview.md
+++ b/docs/30-devops-platform/ci-cd-pipeline-overview.md
@@ -30,7 +30,7 @@ The Portfolio App CI/CD pipeline enforces quality gates via GitHub Actions befor
 | ----------- | ----------- | ---------------------- | ---------------------------------- | -------------------------------- |
 | Preview     | PR branches | Auto on PR creation    | `*.vercel.app` (auto-generated)    | Feature validation and PR review |
 | Staging     | `staging`   | Manual (merge main)    | `staging-bns-portfolio.vercel.app` | Pre-production validation        |
-| Production  | `main`      | Auto (after CI passes) | `bns-portfolio.vercel.app`         | Live public site                 |
+| Production  | `main`      | Auto (after CI passes) | `bryce.seefieldt.ca`               | Live public site                 |
 
 **Deployment flow:** PR → Preview (auto) → Merge to main → CI runs → Production (auto) → Staging (manual) → Production validated
 
@@ -372,7 +372,7 @@ env:
    NEXT_PUBLIC_DOCS_BASE_URL: https://your-docs-domain.example
   NEXT_PUBLIC_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-app
   NEXT_PUBLIC_DOCS_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-docs
-  NEXT_PUBLIC_SITE_URL: https://bns-portfolio.vercel.app
+  NEXT_PUBLIC_SITE_URL: https://bryce.seefieldt.ca
 ```
 
 **Rationale**: Non-sensitive public URLs used for registry interpolation during CI builds

--- a/docs/50-operations/runbooks/rbk-portfolio-deploy.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-deploy.md
@@ -241,13 +241,13 @@ pnpm links:check:external
    - [ ] Status: "Ready" (green checkmark)
    - [ ] Branch: `main`
    - [ ] Commit SHA matches your merged PR
-   - [ ] Production domain assigned: `https://bns-portfolio.vercel.app`
+   - [ ] Production domain assigned: `https://bryce.seefieldt.ca` (canonical domain)
 
 ### 8) Validate Production Deployment
 
 **Manual validation (required after staging passes):**
 
-1. Open `https://bns-portfolio.vercel.app` in browser
+1. Open `https://bryce.seefieldt.ca` in browser
 2. Verify same critical paths as staging:
    - [ ] Home, CV, Projects, Contact pages render
 

--- a/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
@@ -339,8 +339,8 @@ curl -s https://portfolio-app.vercel.app/api/health | jq '.status'
 1. Go to [Vercel Project Settings → Environment Variables](https://vercel.com/bryce-seefieldts-projects/portfolio-app/settings/environment-variables)
 2. Check required variables are present:
    - `NEXT_PUBLIC_GITHUB_URL`: `https://github.com/bryce-seefieldt/portfolio-app`
-   - `NEXT_PUBLIC_DOCS_BASE_URL`: `https://bns-portfolio-docs.vercel.app`
-   - `NEXT_PUBLIC_SITE_URL`: `https://portfolio-app.vercel.app`
+   - `NEXT_PUBLIC_DOCS_BASE_URL`: `https://bryce.seefieldt.ca/docs` (or `https://bns-portfolio-docs.vercel.app` for preview)
+   - `NEXT_PUBLIC_SITE_URL`: `https://bryce.seefieldt.ca`
 3. If missing: Add variable with correct value
 4. If present but wrong: Edit variable value
 5. **Important:** After changing env vars, trigger redeploy:
@@ -381,7 +381,7 @@ vercel domains --clear-cache portfolio-app.vercel.app
 
 ```bash
 # Test docs site availability
-curl -I https://bns-portfolio-docs.vercel.app/
+curl -I https://bryce.seefieldt.ca/docs/
 
 # Test GitHub API
 curl -I https://api.github.com/repos/bryce-seefieldt/portfolio-app

--- a/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
+++ b/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
@@ -578,8 +578,8 @@ Update the team documentation with your actual URLs:
 
 | Variable                    | Preview                                          | Production                                       |
 | --------------------------- | ------------------------------------------------ | ------------------------------------------------ |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | https://bns-portfolio-docs.vercel.app/docs/      | https://bryce.seefieldt.ca/docs                 |
-| `NEXT_PUBLIC_SITE_URL`      | https://bns-portfolio.vercel.app                 | https://bryce.seefieldt.ca                      |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | https://bns-portfolio-docs.vercel.app/docs/      | https://bryce.seefieldt.ca/docs                  |
+| `NEXT_PUBLIC_SITE_URL`      | https://bns-portfolio.vercel.app                 | https://bryce.seefieldt.ca                       |
 | `NEXT_PUBLIC_GITHUB_URL`    | https://github.com/bryce-seefieldt/portfolio-app | https://github.com/bryce-seefieldt/portfolio-app |
 | ...                         | ...                                              | ...                                              |
 ```

--- a/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
+++ b/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
@@ -569,17 +569,17 @@ Update the team documentation with your actual URLs:
 ```markdown
 ## Production URLs (2026-01-16)
 
-- **Portfolio App Production:** https://bns-portfolio.vercel.app
-- **Portfolio App Staging (Preview):** https://staging-bns-portfolio-vercel.app
-- **Portfolio Docs Production:** https://bns-portfolio-docs.vercel.app
-- **Portfolio Docs Preview:** https://bns-portfolio-docs-git-\*.vercel.app (dynamic per PR)
+- **Portfolio App Production:** https://bryce.seefieldt.ca (canonical domain)
+- **Portfolio App Staging (Preview):** https://staging-bns-portfolio-vercel.app (example)
+- **Portfolio Docs Production:** https://bryce.seefieldt.ca/docs (canonical domain)
+- **Portfolio Docs Preview:** https://bns-portfolio-docs.vercel.app (Vercel preview origin)
 
 ### Environment Variables Configured
 
 | Variable                    | Preview                                          | Production                                       |
 | --------------------------- | ------------------------------------------------ | ------------------------------------------------ |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | https://bns-portfolio-docs.vercel.app            | https://bns-portfolio-docs.vercel.app            |
-| `NEXT_PUBLIC_SITE_URL`      | https://bns-portfolio.vercel.app                 | https://portfolio.yourdomain.com                 |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | https://bns-portfolio-docs.vercel.app/docs/      | https://bryce.seefieldt.ca/docs                 |
+| `NEXT_PUBLIC_SITE_URL`      | https://bns-portfolio.vercel.app                 | https://bryce.seefieldt.ca                      |
 | `NEXT_PUBLIC_GITHUB_URL`    | https://github.com/bryce-seefieldt/portfolio-app | https://github.com/bryce-seefieldt/portfolio-app |
 | ...                         | ...                                              | ...                                              |
 ```

--- a/docs/60-projects/portfolio-app/03-deployment.md
+++ b/docs/60-projects/portfolio-app/03-deployment.md
@@ -118,7 +118,7 @@ The Portfolio App operates across three tiers, each serving a distinct purpose i
 
 - **Purpose:** Live public site serving end users
 - **Trigger:** Automatic promotion after CI checks pass (Vercel Deployment Checks)
-- **Domain:** `https://bns-portfolio.vercel.app` (production domain)
+- **Domain:** `https://bryce.seefieldt.ca` (canonical production domain)
 - **Protection:**
   - GitHub Deployment Checks gate promotion (`ci / quality`, `ci / build`)
   - Pipeline prerequisites for successful promotion (`ci / test`, `ci / link-validation`)
@@ -378,7 +378,7 @@ git push origin main
 
 **What happens:**
 
-- Vercel automatically deploys to `https://bns-portfolio.vercel.app`
+- Vercel automatically deploys to `https://bryce.seefieldt.ca`
 - CI checks run on main branch
 - Production domain updates to latest deployment
 
@@ -386,7 +386,7 @@ git push origin main
 
 After production deployment, verify critical flows match staging validation:
 
-- [ ] Open `https://bns-portfolio.vercel.app`
+- [ ] Open `https://bryce.seefieldt.ca`
 - [ ] Validate same routes and flows as staging
 - [ ] Confirm evidence links and navigation work
 - [ ] Check browser console for errors

--- a/docs/60-projects/portfolio-app/06-operations.md
+++ b/docs/60-projects/portfolio-app/06-operations.md
@@ -56,13 +56,13 @@ If MTTR targets are at risk, escalate to team lead immediately. Document all inc
 
 **Local Development → PR Review → Staging Validation → Production**
 
-| Step                         | Branch                          | Action                                                                             | Validation                                                   |
-| ---------------------------- | ------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| **1. Development**           | `feat/your-feature`             | Create feature branch, make changes, run `pnpm verify` locally                     | Pass local validation                                        |
-| **2. PR Review**             | `feat/your-feature` → `staging` | Open PR targeting `staging` (not `main`), get approval                             | CI checks pass, Vercel preview works                         |
-| **3. Merge to Staging**      | `staging`                       | Merge PR to staging branch                                                         | Auto-deploy to staging domain                                |
-| **4. Staging Validation**    | `staging`                       | Manual validation of critical routes on `https://staging-bns-portfolio.vercel.app` | All routes load, evidence links work, no console errors      |
-| **5. Promote to Production** | `staging` → `main`              | Merge staging to main (manual decision point)                                      | Auto-deploy to production `https://bryce.seefieldt.ca` |
+| Step                         | Branch                          | Action                                                                             | Validation                                              |
+| ---------------------------- | ------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **1. Development**           | `feat/your-feature`             | Create feature branch, make changes, run `pnpm verify` locally                     | Pass local validation                                   |
+| **2. PR Review**             | `feat/your-feature` → `staging` | Open PR targeting `staging` (not `main`), get approval                             | CI checks pass, Vercel preview works                    |
+| **3. Merge to Staging**      | `staging`                       | Merge PR to staging branch                                                         | Auto-deploy to staging domain                           |
+| **4. Staging Validation**    | `staging`                       | Manual validation of critical routes on `https://staging-bns-portfolio.vercel.app` | All routes load, evidence links work, no console errors |
+| **5. Promote to Production** | `staging` → `main`              | Merge staging to main (manual decision point)                                      | Auto-deploy to production `https://bryce.seefieldt.ca`  |
 
 **Key Rules:**
 

--- a/docs/60-projects/portfolio-app/06-operations.md
+++ b/docs/60-projects/portfolio-app/06-operations.md
@@ -62,7 +62,7 @@ If MTTR targets are at risk, escalate to team lead immediately. Document all inc
 | **2. PR Review**             | `feat/your-feature` → `staging` | Open PR targeting `staging` (not `main`), get approval                             | CI checks pass, Vercel preview works                         |
 | **3. Merge to Staging**      | `staging`                       | Merge PR to staging branch                                                         | Auto-deploy to staging domain                                |
 | **4. Staging Validation**    | `staging`                       | Manual validation of critical routes on `https://staging-bns-portfolio.vercel.app` | All routes load, evidence links work, no console errors      |
-| **5. Promote to Production** | `staging` → `main`              | Merge staging to main (manual decision point)                                      | Auto-deploy to production `https://bns-portfolio.vercel.app` |
+| **5. Promote to Production** | `staging` → `main`              | Merge staging to main (manual decision point)                                      | Auto-deploy to production `https://bryce.seefieldt.ca` |
 
 **Key Rules:**
 

--- a/docs/_archive/closed-issues/stage-3-4-app-issue.md
+++ b/docs/_archive/closed-issues/stage-3-4-app-issue.md
@@ -86,8 +86,8 @@ The app implementation is minimal for this stage because most Phase 3 decisions 
 
     **Decision references:**
 
-    - ADR-0011: [Data-Driven Registry Decision](https://bns-portfolio-docs.vercel.app/docs/architecture/adr/adr-0011-data-driven-project-registry)
-    - ADR-0012: [Cross-Repo Documentation Linking](https://bns-portfolio-docs.vercel.app/docs/architecture/adr/adr-0012-cross-repo-documentation-linking)
+    - ADR-0011: [Data-Driven Registry Decision](https://bryce.seefieldt.ca/docs/architecture/adr/adr-0011-data-driven-project-registry)
+    - ADR-0012: [Cross-Repo Documentation Linking](https://bryce.seefieldt.ca/docs/architecture/adr/adr-0012-cross-repo-documentation-linking)
     ```
 
 - [x] **Document registry YAML patterns**
@@ -106,7 +106,7 @@ The app implementation is minimal for this stage because most Phase 3 decisions 
     - Environment variable contract (NEXT_PUBLIC_DOCS_BASE_URL, NEXT_PUBLIC_GITHUB_URL, etc.)
     - When to use relative vs. absolute URLs
     - Examples:
-      - ✅ `docsUrl("portfolio/roadmap")` → resolves to `https://bns-portfolio-docs.vercel.app/docs/portfolio/roadmap`
+      - ✅ `docsUrl("portfolio/roadmap")` → resolves to `https://bryce.seefieldt.ca/docs/portfolio/roadmap`
       - ✅ `githubUrl("portfolio-app")` → resolves to `https://github.com/bryce-seefieldt/portfolio-app/portfolio-app` (if env set)
       - ✅ `docsGithubUrl("blob/main/src/lib/registry.ts")` → resolves to docs repo blob URL
 
@@ -133,7 +133,7 @@ The app implementation is minimal for this stage because most Phase 3 decisions 
 
 - [x] **Add Phase 3 reference to README (optional)**
   - Content: Add bullet under "What This App Does" or "Architecture" section
-  - Example: `- Data-driven project registry (YAML + TypeScript validation); see [Registry Guide](https://bns-portfolio-docs.vercel.app/docs/reference/registry-schema-guide)`
+  - Example: `- Data-driven project registry (YAML + TypeScript validation); see [Registry Guide](https://bryce.seefieldt.ca/docs/reference/registry-schema-guide)`
 
 - [x] **Build and verify no broken links**
   - Command: `pnpm build` (local)

--- a/docs/_archive/closed-issues/stage-4-1-docs-issue.md
+++ b/docs/_archive/closed-issues/stage-4-1-docs-issue.md
@@ -221,7 +221,7 @@ Document the architectural decision to adopt explicit three-tier environment sep
      - Command: `git checkout main && git pull && git merge staging && git push`
      - Result: Vercel automatically deploys to production
    - Step 3: Validate production deployment
-     - Test: Visit `https://bns-portfolio.vercel.app`
+     - Test: Visit `https://bryce.seefieldt.ca`
      - Check: Application loads; critical pages accessible
      - Verify: No error spikes in monitoring
    - Step 4: Log promotion event

--- a/docs/_meta/env/portfolio-docs-env-contract.md
+++ b/docs/_meta/env/portfolio-docs-env-contract.md
@@ -109,16 +109,14 @@ This is analogous to Next.js `NEXT_PUBLIC_*` convention in the Portfolio App.
 
 ```typescript
 const config: Config = {
-  url:
-    process.env.DOCUSAURUS_SITE_URL || 'https://bryce.seefieldt.ca/docs',
+  url: process.env.DOCUSAURUS_SITE_URL || 'https://bryce.seefieldt.ca/docs',
   baseUrl: process.env.DOCUSAURUS_BASE_URL || '/docs/',
   organizationName: process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt',
   projectName: process.env.DOCUSAURUS_GITHUB_REPO_DOCS || 'portfolio-docs',
 
   customFields: {
     portfolioAppUrl:
-      process.env.DOCUSAURUS_PORTFOLIO_APP_URL ||
-      'https://bryce.seefieldt.ca',
+      process.env.DOCUSAURUS_PORTFOLIO_APP_URL || 'https://bryce.seefieldt.ca',
     githubOrgUrl: `https://github.com/${process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt'}`,
     githubRepoDocsUrl: `https://github.com/${process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt'}/${process.env.DOCUSAURUS_GITHUB_REPO_DOCS || 'portfolio-docs'}`,
     githubRepoAppUrl: `https://github.com/${process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt'}/${process.env.DOCUSAURUS_GITHUB_REPO_APP || 'portfolio-app'}`,

--- a/docs/_meta/env/portfolio-docs-env-contract.md
+++ b/docs/_meta/env/portfolio-docs-env-contract.md
@@ -34,9 +34,9 @@ This is analogous to Next.js `NEXT_PUBLIC_*` convention in the Portfolio App.
 - **Purpose**: Base URL of the deployed site (used for SEO, sitemap, canonical URLs)
 - **Used in**: `docusaurus.config.ts` (`url` field)
 - **Local**: `http://localhost:3000`
-- **Production**: `https://bns-portfolio-docs.vercel.app`
+- **Production**: `https://bryce.seefieldt.ca/docs` (canonical domain; preview: `https://bns-portfolio-docs.vercel.app`)
 - **Required**: Yes
-- **Default**: `https://bns-portfolio-docs.vercel.app` (fallback in config)
+- **Default**: `https://bryce.seefieldt.ca/docs` (fallback in config)
 
 #### `DOCUSAURUS_BASE_URL`
 
@@ -79,9 +79,9 @@ This is analogous to Next.js `NEXT_PUBLIC_*` convention in the Portfolio App.
 - **Purpose**: URL of the Portfolio App (for cross-linking from docs to live app)
 - **Used in**: `docusaurus.config.ts` (customFields.portfolioAppUrl)
 - **Local**: `http://localhost:3000` (if running portfolio-app locally)
-- **Production**: `https://bns-portfolio-app.vercel.app`
+- **Production**: `https://bryce.seefieldt.ca` (canonical domain; preview: `https://bns-portfolio.vercel.app`)
 - **Required**: No (used for doc → app navigation)
-- **Default**: `https://bns-portfolio-app.vercel.app` (fallback in config)
+- **Default**: `https://bryce.seefieldt.ca` (fallback in config)
 
 ## Optional Variables
 
@@ -110,15 +110,15 @@ This is analogous to Next.js `NEXT_PUBLIC_*` convention in the Portfolio App.
 ```typescript
 const config: Config = {
   url:
-    process.env.DOCUSAURUS_SITE_URL || 'https://bns-portfolio-docs.vercel.app',
-  baseUrl: process.env.DOCUSAURUS_BASE_URL || '/',
+    process.env.DOCUSAURUS_SITE_URL || 'https://bryce.seefieldt.ca/docs',
+  baseUrl: process.env.DOCUSAURUS_BASE_URL || '/docs/',
   organizationName: process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt',
   projectName: process.env.DOCUSAURUS_GITHUB_REPO_DOCS || 'portfolio-docs',
 
   customFields: {
     portfolioAppUrl:
       process.env.DOCUSAURUS_PORTFOLIO_APP_URL ||
-      'https://bns-portfolio-app.vercel.app',
+      'https://bryce.seefieldt.ca',
     githubOrgUrl: `https://github.com/${process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt'}`,
     githubRepoDocsUrl: `https://github.com/${process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt'}/${process.env.DOCUSAURUS_GITHUB_REPO_DOCS || 'portfolio-docs'}`,
     githubRepoAppUrl: `https://github.com/${process.env.DOCUSAURUS_GITHUB_ORG || 'bryce-seefieldt'}/${process.env.DOCUSAURUS_GITHUB_REPO_APP || 'portfolio-app'}`,
@@ -164,7 +164,7 @@ Environment variables set in Vercel dashboard (Project Settings → Environment 
 Environment variables set in Vercel dashboard:
 
 - **Scope**: Production
-- **Values**: Production URLs (`https://bns-portfolio-docs.vercel.app`, etc.)
+- **Values**: Production URLs (`https://bryce.seefieldt.ca/docs`, etc.)
 
 ## File Precedence
 
@@ -228,7 +228,7 @@ grep -r "localhost:3000" build/  # Should appear if DOCUSAURUS_SITE_URL is local
 
 - **Symptom**: Documentation links to portfolio-app use `localhost` in production
 - **Cause**: `DOCUSAURUS_PORTFOLIO_APP_URL` not set correctly in Vercel
-- **Fix**: Set `DOCUSAURUS_PORTFOLIO_APP_URL=https://bns-portfolio-app.vercel.app` in Vercel dashboard (Production scope)
+- **Fix**: Set `DOCUSAURUS_PORTFOLIO_APP_URL=https://bryce.seefieldt.ca` in Vercel dashboard (Production scope)
 
 ### Edit links broken
 


### PR DESCRIPTION
- Replace all hardcoded bns-portfolio-docs.vercel.app and bns-portfolio.vercel.app production references with canonical domain
- Update DOCUSAURUS_SITE_URL and DOCUSAURUS_PORTFOLIO_APP_URL defaults to canonical domain
- Update CONFIGURATION.md environment examples to use bryce.seefieldt.ca
- Update CI/CD pipeline overview environment tiers table to show canonical domain
- Update deployment runbooks to reference bryce.seefieldt.ca (3 runbooks updated)
- Update project deployment docs to use canonical domain (portfolio-app and portfolio-docs)
- Update archived stage 4.1 issue with canonical domain references
- Update env contract documentation with new defaults and examples
- Update copilot session context and internal notes with preview annotations
- Enforce policy: bns-portfolio-docs.vercel.app used ONLY for preview/development

All remaining references to bns-portfolio.vercel.app are explicitly in Preview/Staging columns or clearly marked as preview endpoints.

# Summary

## What changed

This pull request updates all documentation, configuration files, and environment variable references to use the new canonical production domains for both the Portfolio App and Portfolio Docs. The changes ensure consistency across documentation, deployment scripts, and environment variable contracts, reflecting the move from the previous Vercel subdomains to the new custom domains.

**Production Domain and URL Updates:**

* Updated all references to the Portfolio App production domain from `https://bns-portfolio.vercel.app` to `https://bryce.seefieldt.ca` and the Portfolio Docs from `https://bns-portfolio-docs.vercel.app` to `https://bryce.seefieldt.ca/docs` throughout documentation, runbooks, and configuration guides. [[1]](diffhunk://#diff-c66931005262fd01b6423210ed8614170f2f5ba7ce136e22b53e28ee832f15e8L33-R33) [[2]](diffhunk://#diff-e4a60aac139b59a9323b86fdcb75d8b5f73455aeedfbe3d4201f4268c3abf896L244-R250) [[3]](diffhunk://#diff-a209694df1e1bf573bcea5462d1c1170b055a71a12af767a271b466013199200L121-R121) [[4]](diffhunk://#diff-a209694df1e1bf573bcea5462d1c1170b055a71a12af767a271b466013199200L381-R389) [[5]](diffhunk://#diff-10ea91cd24592faee9e424d31ef9c97d7ed5b9630433c6f84850a703a776eaf9L65-R65) [[6]](diffhunk://#diff-45ff1015b4f316101442405318abdba044ff5cdb00512bc985b3840c9acf7898L224-R224) [[7]](diffhunk://#diff-ee274962d28bb9ee92e04802e64b08811c62ca76496d152478ad393c8c2142e6L89-R90) [[8]](diffhunk://#diff-ee274962d28bb9ee92e04802e64b08811c62ca76496d152478ad393c8c2142e6L109-R109) [[9]](diffhunk://#diff-ee274962d28bb9ee92e04802e64b08811c62ca76496d152478ad393c8c2142e6L136-R136) [[10]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L572-R582)

**Environment Variable and Configuration Alignment:**

* Updated environment variable documentation and example values to use the new canonical domains, including `DOCUSAURUS_SITE_URL`, `DOCUSAURUS_BASE_URL`, `DOCUSAURUS_PORTFOLIO_APP_URL`, and related variables in all relevant files. [[1]](diffhunk://#diff-749bbcf2f7f5bd5289d6223d2a4cb36ac92ff1960ca2461b01cbd732ebfbd308L154-R155) [[2]](diffhunk://#diff-749bbcf2f7f5bd5289d6223d2a4cb36ac92ff1960ca2461b01cbd732ebfbd308L173-R173) [[3]](diffhunk://#diff-749bbcf2f7f5bd5289d6223d2a4cb36ac92ff1960ca2461b01cbd732ebfbd308L199-R204) [[4]](diffhunk://#diff-b5fefeb68f802d13ac28a6718c7f03f48afb964e7ca9e02f8227cd36c33ab9c7L37-R39) [[5]](diffhunk://#diff-b5fefeb68f802d13ac28a6718c7f03f48afb964e7ca9e02f8227cd36c33ab9c7L82-R84) [[6]](diffhunk://#diff-b5fefeb68f802d13ac28a6718c7f03f48afb964e7ca9e02f8227cd36c33ab9c7L113-R121) [[7]](diffhunk://#diff-b5fefeb68f802d13ac28a6718c7f03f48afb964e7ca9e02f8227cd36c33ab9c7L167-R167) [[8]](diffhunk://#diff-b5fefeb68f802d13ac28a6718c7f03f48afb964e7ca9e02f8227cd36c33ab9c7L231-R231) [[9]](diffhunk://#diff-8f36adc94e7ed0a13a62696bb176b46d87b6c84cf643e3904f4bcf426f25b136L342-R343) [[10]](diffhunk://#diff-8f36adc94e7ed0a13a62696bb176b46d87b6c84cf643e3904f4bcf426f25b136L384-R384)

**Documentation and Linking Consistency:**

* Ensured all internal and cross-repo documentation links, including ADRs and guides, point to the new canonical docs URLs, and clarified the distinction between preview and production environments. [[1]](diffhunk://#diff-5ce2a6fcd3376ac5d34d0ce662852a075e48ada45e73f7401510c11a1b5567ecL176-R176) [[2]](diffhunk://#diff-ee274962d28bb9ee92e04802e64b08811c62ca76496d152478ad393c8c2142e6L89-R90) [[3]](diffhunk://#diff-ee274962d28bb9ee92e04802e64b08811c62ca76496d152478ad393c8c2142e6L109-R109) [[4]](diffhunk://#diff-ee274962d28bb9ee92e04802e64b08811c62ca76496d152478ad393c8c2142e6L136-R136) [[5]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L572-R582)

These updates guarantee that all documentation and deployment processes reflect the current production setup and reduce the risk of confusion or broken links due to outdated domain references.