### PR TITLE
docs: update env contract and runbooks for vercel.json /docs routing

### DIFF
--- a/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
@@ -219,6 +219,11 @@ vercel env ls --scope production
 # - NEXT_PUBLIC_GITHUB_URL
 # - NEXT_PUBLIC_DOCS_BASE_URL
 # - NEXT_PUBLIC_SITE_URL
+#
+# NOTE: DOCS_UPSTREAM_URL should NOT be present — it is deprecated.
+# /docs routing is handled by vercel.json edge rewrites (no env var needed).
+# If DOCS_UPSTREAM_URL is set to bryce.seefieldt.ca, delete it immediately
+# as it will cause INFINITE_LOOP_DETECTED (508) errors on /docs routes.
 ```
 
 **Mitigation:** Revert env var to previous value if suspected cause, then redeploy.
@@ -262,6 +267,7 @@ Categorize errors by pattern to identify root cause:
 | -------------------------------- | --------------------------------------- | ----------------------------------- |
 | `Cannot load PROJECTS registry`  | Empty or corrupted `projects.yml`       | **Category A: Data Issue**          |
 | `NEXT_PUBLIC_* variable missing` | Environment variable not set            | **Category B: Configuration Issue** |
+| `508 INFINITE_LOOP_DETECTED` on `/docs` | `DOCS_UPSTREAM_URL` set to app's own domain, or `vercel.json` missing | **Category B: Configuration Issue** |
 | `Timeout calling external API`   | Slow/unavailable external dependency    | **Category D: External Dependency** |
 | `Out of memory` / `ETIMEDOUT`    | Resource exhaustion (CPU/memory limits) | **Category C: Resource Issue**      |
 | `Module not found`               | Missing dependency or build failure     | **Category B: Configuration Issue** |

--- a/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
+++ b/docs/50-operations/runbooks/rbk-portfolio-service-degradation.md
@@ -263,14 +263,14 @@ Access logs to find error patterns:
 
 Categorize errors by pattern to identify root cause:
 
-| Error Pattern                    | Likely Cause                            | Root Cause Category                 |
-| -------------------------------- | --------------------------------------- | ----------------------------------- |
-| `Cannot load PROJECTS registry`  | Empty or corrupted `projects.yml`       | **Category A: Data Issue**          |
-| `NEXT_PUBLIC_* variable missing` | Environment variable not set            | **Category B: Configuration Issue** |
+| Error Pattern                           | Likely Cause                                                          | Root Cause Category                 |
+| --------------------------------------- | --------------------------------------------------------------------- | ----------------------------------- |
+| `Cannot load PROJECTS registry`         | Empty or corrupted `projects.yml`                                     | **Category A: Data Issue**          |
+| `NEXT_PUBLIC_* variable missing`        | Environment variable not set                                          | **Category B: Configuration Issue** |
 | `508 INFINITE_LOOP_DETECTED` on `/docs` | `DOCS_UPSTREAM_URL` set to app's own domain, or `vercel.json` missing | **Category B: Configuration Issue** |
-| `Timeout calling external API`   | Slow/unavailable external dependency    | **Category D: External Dependency** |
-| `Out of memory` / `ETIMEDOUT`    | Resource exhaustion (CPU/memory limits) | **Category C: Resource Issue**      |
-| `Module not found`               | Missing dependency or build failure     | **Category B: Configuration Issue** |
+| `Timeout calling external API`          | Slow/unavailable external dependency                                  | **Category D: External Dependency** |
+| `Out of memory` / `ETIMEDOUT`           | Resource exhaustion (CPU/memory limits)                               | **Category C: Resource Issue**      |
+| `Module not found`                      | Missing dependency or build failure                                   | **Category B: Configuration Issue** |
 
 #### Step 3: Identify Root Cause Category
 

--- a/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
+++ b/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
@@ -113,30 +113,20 @@ On the **"Import Project"** page, configure:
 
 Before configuring Vercel, gather the following URLs:
 
-| Variable                    | Local Dev                  | Preview                                                                              | Production                                                     | Example   |
-| --------------------------- | -------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------- | --------- |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | `http://localhost:3001`    | `https://portfolio-docs-preview.vercel.app` OR `https://preview-docs.yourdomain.com` | `https://docs.yourdomain.com` OR `https://yourdomain.com/docs` | See below |
-| `NEXT_PUBLIC_SITE_URL`      | (optional)                 | `https://portfolio-app-git-main.vercel.app`                                          | `https://portfolio.yourdomain.com` (if using custom domain)    | See below |
-| `NEXT_PUBLIC_GITHUB_URL`    | (same across environments) | `https://github.com/bryce-seefieldt`                                                 | `https://github.com/bryce-seefieldt`                           | —         |
-| `NEXT_PUBLIC_LINKEDIN_URL`  | (same across environments) | `https://www.linkedin.com/in/your-handle/`                                           | `https://www.linkedin.com/in/your-handle/`                     | —         |
-| `NEXT_PUBLIC_CONTACT_EMAIL` | (same across environments) | `your-email@example.com`                                                             | `your-email@example.com`                                       | —         |
+| Variable                    | Local Dev                  | Preview                                            | Production                       | Example   |
+| --------------------------- | -------------------------- | -------------------------------------------------- | -------------------------------- | --------- |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | `http://localhost:3001`    | `https://bns-portfolio-docs.vercel.app/docs`       | `https://bryce.seefieldt.ca/docs` | See below |
+| `NEXT_PUBLIC_SITE_URL`      | (optional)                 | `https://portfolio-app-git-main.vercel.app`        | `https://bryce.seefieldt.ca`     | See below |
+| `NEXT_PUBLIC_GITHUB_URL`    | (same across environments) | `https://github.com/bryce-seefieldt`               | `https://github.com/bryce-seefieldt` | —     |
+| `NEXT_PUBLIC_LINKEDIN_URL`  | (same across environments) | `https://www.linkedin.com/in/your-handle/`         | `https://www.linkedin.com/in/your-handle/` | — |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | (same across environments) | `your-email@example.com`                           | `your-email@example.com`         | —         |
 
-**For NEXT_PUBLIC_DOCS_BASE_URL, decide your strategy:**
+**Domain strategy in use:** Path-based (`bryce.seefieldt.ca/docs`).
 
-**Option A: Subdomain (recommended for clarity)**
-
-```
-Preview: https://portfolio-docs-git-preview.vercel.app
-Production: https://docs.yourdomain.com
-```
-
-**Option B: Path-based (simpler DNS)**
-
-```
-Production: https://yourdomain.com/docs
-```
-
-For now, **use Vercel's default preview URLs** and finalize domain strategy later.
+**`NEXT_PUBLIC_DOCS_BASE_URL` routing note:**
+- This variable controls how evidence links are constructed in the browser — it is **not** used for request routing.
+- The actual `/docs/*` proxy (forwarding requests to `bns-portfolio-docs.vercel.app`) is handled by `vercel.json` edge rewrites and requires no env var.
+- **Do not set `DOCS_UPSTREAM_URL`** in Vercel — it is deprecated and unused. If set to the app's own domain it caused `INFINITE_LOOP_DETECTED` (508) in production.
 
 #### Step 2.2: Add environment variables to Vercel
 
@@ -151,25 +141,25 @@ For now, **use Vercel's default preview URLs** and finalize domain strategy late
 
 1. Click **"Add New"** for each variable:
 
-| Name                        | Value                                                                              | Environment Scope |
-| --------------------------- | ---------------------------------------------------------------------------------- | ----------------- |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | Portfolio Docs preview URL (e.g., `https://portfolio-docs-git-preview.vercel.app`) | **Preview**       |
-| `NEXT_PUBLIC_SITE_URL`      | (leave empty or use Vercel preview URL)                                            | **Preview**       |
-| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                                                            | **Preview**       |
-| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                                                          | **Preview**       |
-| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                                                          | **Preview**       |
+| Name                        | Value                                                                         | Environment Scope |
+| --------------------------- | ----------------------------------------------------------------------------- | ----------------- |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | `https://bns-portfolio-docs.vercel.app/docs`                                  | **Preview**       |
+| `NEXT_PUBLIC_SITE_URL`      | (leave empty or use Vercel preview URL)                                       | **Preview**       |
+| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                                                       | **Preview**       |
+| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                                                     | **Preview**       |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                                                     | **Preview**       |
 
 ##### Production (`main`)
 
 1. Click **"Add New"** for each variable:
 
-| Name                        | Value                                                            | Environment Scope |
-| --------------------------- | ---------------------------------------------------------------- | ----------------- |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | Final docs URL (subdomain or path-based)                         | **Production**    |
-| `NEXT_PUBLIC_SITE_URL`      | Your portfolio domain (e.g., `https://portfolio.yourdomain.com`) | **Production**    |
-| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                                          | **Production**    |
-| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                                        | **Production**    |
-| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                                        | **Production**    |
+| Name                        | Value                                    | Environment Scope |
+| --------------------------- | ---------------------------------------- | ----------------- |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | `https://bryce.seefieldt.ca/docs`        | **Production**    |
+| `NEXT_PUBLIC_SITE_URL`      | `https://bryce.seefieldt.ca`             | **Production**    |
+| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                  | **Production**    |
+| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                | **Production**    |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                | **Production**    |
 
 :::tip
 **Deployment Trigger:** After adding/modifying environment variables, you must redeploy:

--- a/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
+++ b/docs/50-operations/runbooks/rbk-vercel-setup-and-promotion-validation.md
@@ -113,17 +113,18 @@ On the **"Import Project"** page, configure:
 
 Before configuring Vercel, gather the following URLs:
 
-| Variable                    | Local Dev                  | Preview                                            | Production                       | Example   |
-| --------------------------- | -------------------------- | -------------------------------------------------- | -------------------------------- | --------- |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | `http://localhost:3001`    | `https://bns-portfolio-docs.vercel.app/docs`       | `https://bryce.seefieldt.ca/docs` | See below |
-| `NEXT_PUBLIC_SITE_URL`      | (optional)                 | `https://portfolio-app-git-main.vercel.app`        | `https://bryce.seefieldt.ca`     | See below |
-| `NEXT_PUBLIC_GITHUB_URL`    | (same across environments) | `https://github.com/bryce-seefieldt`               | `https://github.com/bryce-seefieldt` | —     |
-| `NEXT_PUBLIC_LINKEDIN_URL`  | (same across environments) | `https://www.linkedin.com/in/your-handle/`         | `https://www.linkedin.com/in/your-handle/` | — |
-| `NEXT_PUBLIC_CONTACT_EMAIL` | (same across environments) | `your-email@example.com`                           | `your-email@example.com`         | —         |
+| Variable                    | Local Dev                  | Preview                                      | Production                                 | Example   |
+| --------------------------- | -------------------------- | -------------------------------------------- | ------------------------------------------ | --------- |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | `http://localhost:3001`    | `https://bns-portfolio-docs.vercel.app/docs` | `https://bryce.seefieldt.ca/docs`          | See below |
+| `NEXT_PUBLIC_SITE_URL`      | (optional)                 | `https://portfolio-app-git-main.vercel.app`  | `https://bryce.seefieldt.ca`               | See below |
+| `NEXT_PUBLIC_GITHUB_URL`    | (same across environments) | `https://github.com/bryce-seefieldt`         | `https://github.com/bryce-seefieldt`       | —         |
+| `NEXT_PUBLIC_LINKEDIN_URL`  | (same across environments) | `https://www.linkedin.com/in/your-handle/`   | `https://www.linkedin.com/in/your-handle/` | —         |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | (same across environments) | `your-email@example.com`                     | `your-email@example.com`                   | —         |
 
 **Domain strategy in use:** Path-based (`bryce.seefieldt.ca/docs`).
 
 **`NEXT_PUBLIC_DOCS_BASE_URL` routing note:**
+
 - This variable controls how evidence links are constructed in the browser — it is **not** used for request routing.
 - The actual `/docs/*` proxy (forwarding requests to `bns-portfolio-docs.vercel.app`) is handled by `vercel.json` edge rewrites and requires no env var.
 - **Do not set `DOCS_UPSTREAM_URL`** in Vercel — it is deprecated and unused. If set to the app's own domain it caused `INFINITE_LOOP_DETECTED` (508) in production.
@@ -141,25 +142,25 @@ Before configuring Vercel, gather the following URLs:
 
 1. Click **"Add New"** for each variable:
 
-| Name                        | Value                                                                         | Environment Scope |
-| --------------------------- | ----------------------------------------------------------------------------- | ----------------- |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | `https://bns-portfolio-docs.vercel.app/docs`                                  | **Preview**       |
-| `NEXT_PUBLIC_SITE_URL`      | (leave empty or use Vercel preview URL)                                       | **Preview**       |
-| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                                                       | **Preview**       |
-| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                                                     | **Preview**       |
-| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                                                     | **Preview**       |
+| Name                        | Value                                        | Environment Scope |
+| --------------------------- | -------------------------------------------- | ----------------- |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | `https://bns-portfolio-docs.vercel.app/docs` | **Preview**       |
+| `NEXT_PUBLIC_SITE_URL`      | (leave empty or use Vercel preview URL)      | **Preview**       |
+| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                      | **Preview**       |
+| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                    | **Preview**       |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                    | **Preview**       |
 
 ##### Production (`main`)
 
 1. Click **"Add New"** for each variable:
 
-| Name                        | Value                                    | Environment Scope |
-| --------------------------- | ---------------------------------------- | ----------------- |
-| `NEXT_PUBLIC_DOCS_BASE_URL` | `https://bryce.seefieldt.ca/docs`        | **Production**    |
-| `NEXT_PUBLIC_SITE_URL`      | `https://bryce.seefieldt.ca`             | **Production**    |
-| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL                  | **Production**    |
-| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL                | **Production**    |
-| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email                | **Production**    |
+| Name                        | Value                             | Environment Scope |
+| --------------------------- | --------------------------------- | ----------------- |
+| `NEXT_PUBLIC_DOCS_BASE_URL` | `https://bryce.seefieldt.ca/docs` | **Production**    |
+| `NEXT_PUBLIC_SITE_URL`      | `https://bryce.seefieldt.ca`      | **Production**    |
+| `NEXT_PUBLIC_GITHUB_URL`    | Your GitHub profile URL           | **Production**    |
+| `NEXT_PUBLIC_LINKEDIN_URL`  | Your LinkedIn profile URL         | **Production**    |
+| `NEXT_PUBLIC_CONTACT_EMAIL` | Your public contact email         | **Production**    |
 
 :::tip
 **Deployment Trigger:** After adding/modifying environment variables, you must redeploy:

--- a/docs/60-projects/portfolio-app/03-deployment.md
+++ b/docs/60-projects/portfolio-app/03-deployment.md
@@ -143,13 +143,11 @@ Examples by environment:
 # Local development (docs running on localhost:3001)
 NEXT_PUBLIC_DOCS_BASE_URL=http://localhost:3001
 
-# Preview deployments (Vercel preview URL or dedicated preview docs domain)
-NEXT_PUBLIC_DOCS_BASE_URL=https://portfolio-docs-git-preview-branch.vercel.app
+# Preview deployments (Vercel preview URL for portfolio-docs)
+NEXT_PUBLIC_DOCS_BASE_URL=https://bns-portfolio-docs.vercel.app/docs
 
-# Production (final docs domain)
-NEXT_PUBLIC_DOCS_BASE_URL=https://docs.yourdomain.com
-# OR path-based:
-NEXT_PUBLIC_DOCS_BASE_URL=https://yourdomain.com/docs
+# Production (canonical path-based strategy)
+NEXT_PUBLIC_DOCS_BASE_URL=https://bryce.seefieldt.ca/docs
 
 **`NEXT_PUBLIC_SITE_URL`**
 
@@ -193,6 +191,29 @@ NEXT_PUBLIC_DOCS_BASE_URL=https://yourdomain.com/docs
    - **Preview**: preview/staging URLs
    - **Development**: optional (can use `.env.local`)
 3. Redeploy after variable changes to apply
+
+### `/docs` path routing (vercel.json)
+
+The Portfolio App serves documentation at `/docs/*` via Vercel edge-layer rewrites defined in `vercel.json` — **not** via environment variables or `next.config.ts` rewrites.
+
+```json
+{
+  "rewrites": [
+    { "source": "/docs", "destination": "https://bns-portfolio-docs.vercel.app/docs" },
+    { "source": "/docs/:path*", "destination": "https://bns-portfolio-docs.vercel.app/docs/:path*" }
+  ]
+}
+```
+
+**Why `vercel.json` (not `next.config.ts`):**
+
+- `next.config.ts` `rewrites()` are evaluated at **build time** and depend on env vars being present during build. If `DOCS_UPSTREAM_URL` was pointed at the same Vercel project's custom domain (`bryce.seefieldt.ca`), Vercel detects a circular hop and returns `508 INFINITE_LOOP_DETECTED`.
+- `vercel.json` rewrites are evaluated at **Vercel edge request time**, have no env var dependency, and cannot form loops between different Vercel projects.
+- The docs origin (`bns-portfolio-docs.vercel.app`) is not a secret and is safe to hardcode.
+
+**Do not:**
+- Set `DOCS_UPSTREAM_URL` in Vercel — this variable is deprecated and unused.
+- Add `/docs` rewrites back to `next.config.ts` — this caused the production loop incident.
 
 ## CI contract (GitHub Actions)
 

--- a/docs/60-projects/portfolio-app/03-deployment.md
+++ b/docs/60-projects/portfolio-app/03-deployment.md
@@ -199,8 +199,14 @@ The Portfolio App serves documentation at `/docs/*` via Vercel edge-layer rewrit
 ```json
 {
   "rewrites": [
-    { "source": "/docs", "destination": "https://bns-portfolio-docs.vercel.app/docs" },
-    { "source": "/docs/:path*", "destination": "https://bns-portfolio-docs.vercel.app/docs/:path*" }
+    {
+      "source": "/docs",
+      "destination": "https://bns-portfolio-docs.vercel.app/docs"
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://bns-portfolio-docs.vercel.app/docs/:path*"
+    }
   ]
 }
 ```
@@ -212,6 +218,7 @@ The Portfolio App serves documentation at `/docs/*` via Vercel edge-layer rewrit
 - The docs origin (`bns-portfolio-docs.vercel.app`) is not a secret and is safe to hardcode.
 
 **Do not:**
+
 - Set `DOCS_UPSTREAM_URL` in Vercel — this variable is deprecated and unused.
 - Add `/docs` rewrites back to `next.config.ts` — this caused the production loop incident.
 

--- a/docs/_meta/env/portfolio-app-env-contract.md
+++ b/docs/_meta/env/portfolio-app-env-contract.md
@@ -24,12 +24,15 @@ Define the canonical environment variable contract for the **Portfolio App** (Ne
 **Purpose:** Base URL for the Documentation App evidence engine.  
 **Examples:**
 
-- Path strategy: `https://yourdomain.com/docs`
-- Subdomain strategy: `https://docs.yourdomain.com`
+- Local development: `http://localhost:3001`
+- Preview deployments: `https://bns-portfolio-docs.vercel.app/docs`
+- Production (path-based): `https://bryce.seefieldt.ca/docs`
 
 **Fallback behavior:** If unset, the app defaults to `"/docs"`. This is only correct if documentation is truly served at that path.
 
 **Used by:** `DOCS_BASE_URL` and `docsUrl()` helper.
+
+**Note on `/docs` routing:** The Portfolio App serves `/docs/*` via Vercel edge-layer rewrites in `vercel.json` — not via an env var. `NEXT_PUBLIC_DOCS_BASE_URL` controls how evidence links are constructed in the browser; the actual request routing to `bns-portfolio-docs.vercel.app` is handled separately at the edge. Do not set `DOCS_UPSTREAM_URL` in Vercel — it is deprecated and unused.
 
 ### Optional (recommended for production polish)
 
@@ -82,11 +85,13 @@ Set environment variables in Vercel Project Settings for:
 
 Minimum recommended in Vercel:
 
-- `NEXT_PUBLIC_DOCS_BASE_URL`
-- `NEXT_PUBLIC_SITE_URL`
+- `NEXT_PUBLIC_DOCS_BASE_URL` (e.g., `https://bryce.seefieldt.ca/docs` for production)
+- `NEXT_PUBLIC_SITE_URL` (e.g., `https://bryce.seefieldt.ca`)
 - `NEXT_PUBLIC_GITHUB_URL`
 - `NEXT_PUBLIC_LINKEDIN_URL`
 - Optional: `NEXT_PUBLIC_CONTACT_EMAIL`
+
+> **Do not set** `DOCS_UPSTREAM_URL` — this variable is deprecated. The `/docs` reverse-proxy rewrite is now handled by `vercel.json` at the Vercel edge layer with no env var dependency.
 
 ## CI determinism (required)
 


### PR DESCRIPTION
- 03-deployment.md: add /docs routing section explaining vercel.json edge rewrites; update NEXT_PUBLIC_DOCS_BASE_URL examples with actual production values (bryce.seefieldt.ca/docs)
- portfolio-app-env-contract.md: update NEXT_PUBLIC_DOCS_BASE_URL examples with concrete URLs; deprecate DOCS_UPSTREAM_URL; add routing note
- rbk-vercel-setup-and-promotion-validation.md: replace generic placeholder URLs with actual bryce.seefieldt.ca values; add DOCS_UPSTREAM_URL warning
- rbk-portfolio-service-degradation.md: add 508 loop error pattern to triage table; annotate expected env vars with DOCS_UPSTREAM_URL deprecation note

# Summary
This pull request updates documentation to clarify and standardize how documentation routing and environment variables are managed for the Portfolio App, especially regarding the deprecation of the `DOCS_UPSTREAM_URL` variable. It replaces legacy guidance with the current canonical approach, emphasizing the use of Vercel edge rewrites in `vercel.json` for `/docs` routing, and updates all relevant environment variable examples to match the production deployment. The changes also add warnings and troubleshooting steps for configuration errors that could cause infinite loops.

Key changes:

**Routing and Environment Variable Guidance:**
- Clarified that `/docs` routing is handled exclusively by `vercel.json` edge rewrites, not by environment variables or `next.config.ts`. The `DOCS_UPSTREAM_URL` variable is now deprecated and should not be set, as its misuse can cause infinite redirect loops and production outages. [[1]](diffhunk://#diff-8f36adc94e7ed0a13a62696bb176b46d87b6c84cf643e3904f4bcf426f25b136R222-R226) [[2]](diffhunk://#diff-a209694df1e1bf573bcea5462d1c1170b055a71a12af767a271b466013199200R195-R217) [[3]](diffhunk://#diff-883a165a9a5b67fd2706976de617378c8f7562e858098ea79c56e37f561c13f5L27-R36) [[4]](diffhunk://#diff-883a165a9a5b67fd2706976de617378c8f7562e858098ea79c56e37f561c13f5L85-R95)
- Updated all documentation examples and tables to use the canonical production and preview URLs (`https://bryce.seefieldt.ca/docs` and `https://bns-portfolio-docs.vercel.app/docs`), and clarified the role of `NEXT_PUBLIC_DOCS_BASE_URL` as a browser-only variable for evidence links. [[1]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L117-R129) [[2]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L155-R146) [[3]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L167-R159) [[4]](diffhunk://#diff-a209694df1e1bf573bcea5462d1c1170b055a71a12af767a271b466013199200L146-R150) [[5]](diffhunk://#diff-883a165a9a5b67fd2706976de617378c8f7562e858098ea79c56e37f561c13f5L27-R36)

**Incident Prevention and Troubleshooting:**
- Added explicit warnings and troubleshooting steps regarding the deprecated `DOCS_UPSTREAM_URL` variable, including how its misconfiguration can cause `508 INFINITE_LOOP_DETECTED` errors on `/docs` routes.
- Updated the error categorization table to include the infinite loop error, with root cause and mitigation steps.

**General Documentation Improvements:**
- Removed outdated subdomain/path-based strategy options and replaced them with the current path-based approach.
- Provided clear instructions for setting environment variables in Vercel, including explicit values for production and preview environments. [[1]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L155-R146) [[2]](diffhunk://#diff-2c9e76df26d62bace0a4a06f379a6f9ad2a54e8e012d5562c0abcf541ac85750L167-R159) [[3]](diffhunk://#diff-883a165a9a5b67fd2706976de617378c8f7562e858098ea79c56e37f561c13f5L85-R95)

These updates help prevent future misconfigurations, clarify the separation between browser-side and server-side routing, and ensure that all team members are following the current best practices for environment setup and troubleshooting.